### PR TITLE
Support writing more file formats

### DIFF
--- a/src/gdal_writer.cpp
+++ b/src/gdal_writer.cpp
@@ -133,6 +133,8 @@ namespace exactextract {
             return "CSV";
         } else if (ends_with(filename, ".dbf")) {
             return "ESRI Shapefile";
+        } else if (ends_with(filename, ".gpkg")) {
+            return "GPKG";
         } else if (ends_with(filename, ".nc")) {
             return "NetCDF";
         } else if (starts_with(filename, "PG:")) {


### PR DESCRIPTION
Does this work?

There is probably a better way to do this. It looks like GDAL/ogr already knows how to find the correct driver to use from arbitrary file extensions? https://github.com/OSGeo/gdal/search?q=CPLGetExtension