### PR TITLE
Coverage fraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,11 +65,16 @@ if(BUILD_CLI)
         src/gdal_dataset_wrapper.cpp
         src/gdal_writer.h
         src/gdal_writer.cpp
+        src/coverage_writer.h
+        src/coverage_writer.cpp
         src/processor.h
         src/feature_sequential_processor.cpp
         src/feature_sequential_processor.h
         src/raster_sequential_processor.cpp
         src/raster_sequential_processor.h
+        src/coverage_processor.cpp
+        src/coverage_processor.h
+        src/raster_source.h
     )
 
     add_executable(${BIN_NAME} ${BIN_SOURCES})

--- a/src/coverage_processor.cpp
+++ b/src/coverage_processor.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2019-2020 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file coverage_processor.cpp
+ * @author Nels Frazier (nfrazier@lynker.com)
+ * @brief Implementation of coverage processor
+ * @version 0.1
+ * @date 2022-03-24
+ * 
+ * @copyright Copyright (c) 2022
+ * 
+ */
+#include "coverage_processor.h"
+
+#include <map>
+#include <memory>
+#include <set>
+
+namespace exactextract {
+
+    void CoverageProcessor::process() {
+    
+        while (m_shp.next()) {
+            std::string name{ m_shp.feature_field(m_shp.id_field()) };
+            auto geom = geos_ptr(m_geos_context, m_shp.feature_geometry(m_geos_context));
+
+            progress(name);
+
+            Box feature_bbox = exactextract::geos_get_box(m_geos_context, geom.get());
+
+            auto grid = m_common_grid; 
+            if (feature_bbox.intersects(grid.extent())) {
+                // Crop grid to portion overlapping feature
+                auto cropped_grid = grid.crop(feature_bbox);
+
+                for (const auto &subgrid : subdivide(cropped_grid, m_max_cells_in_memory)) {
+                    std::unique_ptr<Raster<float>> coverage;
+
+                    // Lazy-initialize coverage
+                    if (coverage == nullptr) {
+                        coverage = std::make_unique<Raster<float>>(
+                                raster_cell_intersection(subgrid, m_geos_context, geom.get()));
+                    }
+
+                    m_output.write_coverage(name, *coverage, grid);
+
+                    progress();
+                    
+                }
+            }
+
+        }
+
+    }
+
+}

--- a/src/coverage_processor.h
+++ b/src/coverage_processor.h
@@ -1,0 +1,99 @@
+// Copyright (c) 2019 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EXACTEXTRACT_RASTER_WEIGHT_PROCESSOR_H
+#define EXACTEXTRACT_RASTER_WEIGHT_PROCESSOR_H
+/**
+ * @file coverage_processor.h
+ * @author Nels Frazier (nfrazier@lynker.com)
+ * @brief A processor for computing coverage_fraction of raster pixels for vector features
+ * @version 0.1
+ * @date 2022-03-24
+ * 
+ * @copyright Copyright (c) 2022
+ * 
+ * I tried implementing the raster_sequential_processor logic as follows,
+ * but I could not get the correct global grid cell number mapping using this
+ * so I reverted to simple feature sequential logic, which works well.
+ * 
+ * void CoverageProcessor::process() {
+ *      read_features();
+ *      populate_index();
+ *      auto grid = m_common_grid;
+ *      std::cout<<"HERERERE\n";
+ *      for (const auto &subgrid : subdivide(grid, m_max_cells_in_memory)) {
+ *            std::vector<const Feature *> hits;
+ *
+ *            auto query_rect = geos_make_box_polygon(m_geos_context, subgrid.extent());
+ *
+ *            GEOSSTRtree_query_r(m_geos_context, m_feature_tree.get(), query_rect.get(), [](void *hit, void *userdata) {
+ *                auto feature = static_cast<const Feature *>(hit);
+ *                auto vec = static_cast<std::vector<const Feature *> *>(userdata);
+ *
+ *                vec->push_back(feature);
+ *            }, &hits);
+ *
+ *            for (const auto &f : hits) {
+ *                std::unique_ptr<Raster<float>> coverage;
+ *
+ *                // Lazy-initialize coverage
+ *                if (coverage == nullptr) {
+ *                    coverage = std::make_unique<Raster<float>>(
+ *                            raster_cell_intersection(subgrid, m_geos_context, f->second.get()));
+ *                }
+ *                
+ *                m_output.write_coverage(f->first, *coverage, grid);
+ *                progress();
+ *            }
+ *
+ *            progress(subgrid.extent());
+ *        }
+ */
+
+#include "feature_sequential_processor.h"
+#include "geos_utils.h"
+#include "processor.h"
+#include "grid.h"
+#include "gdal_raster_wrapper.h"
+
+namespace exactextract {
+
+    class CoverageProcessor : public FeatureSequentialProcessor {
+        /*
+            Processor dedicated to computing only coverage fraction
+        */
+
+    private:
+        using RasterMap = std::unordered_map<std::string, GDALRasterWrapper>;
+    public:
+        
+        CoverageProcessor(GDALDatasetWrapper & ds, OutputWriter & out, RasterMap & rasters):
+            FeatureSequentialProcessor(ds, out, {}),
+            m_common_grid( Grid<bounded_extent>::make_empty() )
+        {
+            for(const auto& layer : rasters ){
+                auto grid = layer.second.grid();
+                m_common_grid = grid.common_grid(m_common_grid);
+            }
+        }
+        
+        void process() override;
+
+    private:
+    
+        exactextract::Grid<bounded_extent> m_common_grid;
+
+    };
+}
+
+#endif //EXACTEXTRACT_RASTER_WEIGHT_PROCESSOR_H

--- a/src/coverage_writer.cpp
+++ b/src/coverage_writer.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) 2019 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file coverage_writer.cpp
+ * @author Nels Frazier (nfrazier@lynker.com)
+ * @brief Custom output writer for writing coverage fraction and cell number
+ * @version 0.1
+ * @date 2022-03-24
+ * 
+ * @copyright Copyright (c) 2022
+ * 
+ */
+#include "coverage_writer.h"
+#include "gdal_dataset_wrapper.h"
+#include "stats_registry.h"
+#include "utils.h"
+
+#include "gdal.h"
+#include "ogr_api.h"
+#include "cpl_string.h"
+
+#include <stdexcept>
+
+namespace exactextract {
+    //Static initialization
+    const std::string CoverageWriter::m_coverage_field = "coverage_fraction";
+    const std::string CoverageWriter::m_cell_number_field = "cell_number";
+
+    CoverageWriter::CoverageWriter(const std::string & filename):
+        GDALWriter(filename), fields_initialized(false)
+    {
+        
+    }
+
+    void CoverageWriter::initialize_fields()
+    {
+        if(!fields_initialized)
+        {
+            ///Make sure coverage_fraction and cell_number fields are created
+            auto cov_def = OGR_Fld_Create(m_coverage_field.c_str(), OFTReal);
+            OGR_L_CreateField(m_layer, cov_def, true);
+            OGR_Fld_Destroy(cov_def);
+            auto cell_def = OGR_Fld_Create(m_cell_number_field.c_str(), OFTInteger64);
+            OGR_L_CreateField(m_layer, cell_def, true);
+            OGR_Fld_Destroy(cell_def);
+
+            ///Make sure coverage_fraction and cell_number fields are created
+            auto row_def = OGR_Fld_Create("row", OFTInteger64);
+            OGR_L_CreateField(m_layer, row_def, true);
+            OGR_Fld_Destroy(row_def);
+            auto col_def = OGR_Fld_Create("col", OFTInteger64);
+            OGR_L_CreateField(m_layer, col_def, true);
+            OGR_Fld_Destroy(col_def);
+
+            fields_initialized = true;
+        }
+    }
+
+    void CoverageWriter::add_id_field(const std::string & field_name, const std::string & field_type){
+        m_id_field = field_name;
+        GDALWriter::add_id_field(field_name, field_type);
+    }
+
+    void CoverageWriter::copy_id_field(const GDALDatasetWrapper & w){
+        m_id_field = w.id_field();
+        GDALWriter::copy_id_field(w);
+    }
+
+    void CoverageWriter::write(const std::string & fid) {
+        //Since this writer is not intended to write per feature stat data,
+        //but is instead intended to write raster coverage
+        //we intentionally override the `write` function and throw an error
+        //if it is used.  use `write_coverage` instead
+
+        (void)fid; //suppress unused parameter compiler warning/error
+        throw std::runtime_error("Unimplemented Error: CoverageWriter doesn't implement write, use 'write_coverage' instead");
+    }
+
+    void CoverageWriter::write_coverage(const std::string & fid, const Raster<float>& raster, const Grid<bounded_extent> & common_grid) {
+        initialize_fields();
+        for (size_t i = 0; i < raster.rows(); i++) {
+                for (size_t j = 0; j < raster.cols(); j++) {
+                    float pct_cov = raster(i, j);
+                    
+                    if (pct_cov > 0) {
+                        size_t cell_number = raster.grid().map_to_grid_cell(i, j, common_grid);
+                        //Create the feature
+                        auto feature = OGR_F_Create(OGR_L_GetLayerDefn(m_layer));
+                        const auto id_field_pos = OGR_F_GetFieldIndex(feature, m_id_field.c_str());
+                        OGR_F_SetFieldString(feature, id_field_pos, fid.c_str());
+                        const auto cov_field_pos = OGR_F_GetFieldIndex(feature, m_coverage_field.c_str());
+                        const auto cell_field_pos = OGR_F_GetFieldIndex(feature, m_cell_number_field.c_str());
+                        const auto row_field_pos = OGR_F_GetFieldIndex(feature, "row");
+                        const auto col_field_pos = OGR_F_GetFieldIndex(feature, "col");
+                        OGR_F_SetFieldDouble(feature, cov_field_pos, pct_cov);
+                        OGR_F_SetFieldDouble(feature, row_field_pos, i+common_grid.row_offset(raster.grid()));
+                        OGR_F_SetFieldDouble(feature, col_field_pos, j+common_grid.col_offset(raster.grid()));
+                        OGR_F_SetFieldDouble(feature, cell_field_pos, cell_number);
+                        if (OGR_L_CreateFeature(m_layer, feature) != OGRERR_NONE) {
+                            throw std::runtime_error("Error writing results for record: " + fid);
+                        }
+                        OGR_F_Destroy(feature);
+                    }
+                }
+            } 
+    }
+
+}

--- a/src/coverage_writer.h
+++ b/src/coverage_writer.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2019 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EXACTEXTRACT_COVERAGE_WRITER_H
+#define EXACTEXTRACT_COVERAGE_WRITER_H
+/**
+ * @file coverage_writer.h
+ * @author Nels Frazier (nfrazier@lynker.com)
+ * @brief Custom output writer for writing coverage fraction and cell number
+ * @version 0.1
+ * @date 2022-03-24
+ * 
+ * @copyright Copyright (c) 2022
+ * 
+ */
+#include "raster.h"
+#include "gdal_writer.h"
+
+namespace exactextract {
+
+    /*
+        Custom writer for writing coverage fraction
+    */
+    class CoverageWriter: public GDALWriter {
+
+    public:
+        explicit CoverageWriter(const std::string & filename);
+
+        ~CoverageWriter(){};
+
+        void write(const std::string & fid) override;
+
+        void add_id_field(const std::string & field_name, const std::string & field_type) override;
+
+        void copy_id_field(const GDALDatasetWrapper & w) override;
+
+        void write_coverage(const std::string & fid, const Raster<float> & raster, const Grid<bounded_extent> & common_grid) override;
+
+    private:
+        void inline initialize_fields();
+        static const std::string m_coverage_field;
+        static const std::string m_cell_number_field;
+        std::string m_id_field;
+        bool fields_initialized;
+    };
+
+}
+
+#endif //EXACTEXTRACT_COVERAGE_WRITER_H

--- a/src/exactextract.cpp
+++ b/src/exactextract.cpp
@@ -11,6 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @file exactextract.cpp
+ * @version 0.1
+ * @date 2022-03-24
+ * 
+ * Changelog:
+ *  version 0.1
+ *      Nels Frazier (nfrazier@lynker.com) add a coverage_fraction strategey that only outputs coverage fraction
+ * 
+ */
+
 #include <exception>
 #include <iostream>
 #include <memory>
@@ -23,10 +34,12 @@
 #include "gdal_dataset_wrapper.h"
 #include "gdal_raster_wrapper.h"
 #include "gdal_writer.h"
+#include "coverage_writer.h"
 #include "operation.h"
 #include "processor.h"
 #include "feature_sequential_processor.h"
 #include "raster_sequential_processor.h"
+#include "coverage_processor.h"
 #include "utils.h"
 #include "version.h"
 
@@ -96,6 +109,15 @@ int main(int argc, char** argv) {
             proc = std::make_unique<exactextract::FeatureSequentialProcessor>(shp, *writer, operations);
         } else if (strategy == "raster-sequential") {
             proc = std::make_unique<exactextract::RasterSequentialProcessor>(shp, *writer, operations);
+        } else if (strategy == "coverage_fraction"){
+            auto coverage_writer = std::make_unique<exactextract::CoverageWriter>(output_filename);
+            if (!id_name.empty() && !id_type.empty()) {
+                coverage_writer->add_id_field(id_name, id_type);
+            } else {
+                coverage_writer->copy_id_field(shp);
+            }
+            writer = std::move(coverage_writer);
+            proc = std::make_unique<exactextract::CoverageProcessor>(shp, *writer, rasters);
         } else {
             throw std::runtime_error("Unknown processing strategy: " + strategy);
         }

--- a/src/gdal_writer.cpp
+++ b/src/gdal_writer.cpp
@@ -137,7 +137,9 @@ namespace exactextract {
             return "NetCDF";
         } else if (starts_with(filename, "PG:")) {
             return "PostgreSQL";
-        } else {
+        } else if (ends_with(filename, "json")){
+            return "GeoJSON";
+        }else {
             throw std::runtime_error("Unknown output format: " + filename);
         }
     }

--- a/src/gdal_writer.h
+++ b/src/gdal_writer.h
@@ -37,14 +37,14 @@ namespace exactextract {
 
         void add_id_field(const std::string & field_name, const std::string & field_type);
 
-        void copy_id_field(const GDALDatasetWrapper & w);
+    protected:
+        using OGRLayerH = void*;
+        OGRLayerH m_layer;
 
     private:
         using GDALDatasetH = void*;
-        using OGRLayerH = void*;
 
         GDALDatasetH m_dataset;
-        OGRLayerH m_layer;
         const StatsRegistry* m_reg;
         bool id_field_defined = false;
     };

--- a/src/gdal_writer.h
+++ b/src/gdal_writer.h
@@ -11,9 +11,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @file gdal_writer.h
+ * @version 0.1
+ * @date 2022-03-24
+ * 
+ * Changelog:
+ *  version 0.1
+ *      Nels Frazier (nfrazier@lynker.com) implemented write_coverage
+ *      Nels Frazier (nfrazier@lynker.com) marked add_id_field, copy_id_field as virtual
+ *      Nels Frazier (nfrazier@lynker.com) made OGRLayerH protected so it can be used by subclasses
+ * 
+ */
 #ifndef EXACTEXTRACT_GDAL_WRITER_H
 #define EXACTEXTRACT_GDAL_WRITER_H
 
+#include "raster.h"
 #include "output_writer.h"
 
 namespace exactextract {
@@ -35,7 +48,16 @@ namespace exactextract {
 
         void write(const std::string & fid) override;
 
-        void add_id_field(const std::string & field_name, const std::string & field_type);
+        void write_coverage(const std::string & fid, const Raster<float> & raster, const Grid<bounded_extent> & common_grid) override {
+            (void)fid;
+            (void)raster;
+            (void)common_grid;
+            throw std::runtime_error("Unimplemented Error: GDALWriter doesn't implement write_coverage, use 'write' instead");
+        };
+
+        virtual void add_id_field(const std::string & field_name, const std::string & field_type);
+
+        virtual void copy_id_field(const GDALDatasetWrapper & w);
 
     protected:
         using OGRLayerH = void*;

--- a/src/grid.h
+++ b/src/grid.h
@@ -11,6 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @file grid.h
+ * @version 0.1
+ * @date 2022-03-24
+ * 
+ * Changelog:
+ *  version 0.1
+ *      Nels Frazier (nfrazier@lynker.com) add map_to_grid_cell function to map row,col pairs to grid cell numbers
+ * 
+ */
+
 #ifndef EXACTEXTRACT_GRID_H
 #define EXACTEXTRACT_GRID_H
 
@@ -318,6 +329,45 @@ namespace exactextract {
 
         bool operator!=(const Grid<extent_tag> &b) const {
             return !(*this == b);
+        }
+
+        /**
+         * @brief Compute the cell number that row,column corresponds to
+         * 
+         * If passed a global grid that is compatible with the grid, the grid cell
+         * will computed in the global grid.
+         * 
+         * This function returns cells assuming a 1-based index into the flattened
+         * raster.
+         * 
+         * @tparam extent_tag2 
+         * @param row row index in the local grid
+         * @param col column index in the local grid
+         * @param global (optional) global grid to map local cell to
+         * @return size_t cell number of the raster (local or global)
+         */
+        template<typename extent_tag2>
+        size_t map_to_grid_cell(const size_t & row, const size_t & col, Grid<extent_tag2> global = Grid<extent_tag2>::make_empty() ) const {
+            if(global.empty()){
+                //get grid cell on local
+                global = *this;
+            } else if (!this->compatible_with(global, 1e-6)) {
+                //cannot map local into global grid
+                throw std::runtime_error("Incompatible extents.");
+            }
+            //This is the row idx where local would start in the global grid
+            size_t row_offset = global.row_offset(*this);
+            //This is the column idx where local would start in the global grid
+            //offset by 1 to shift from 0 to 1 starting index
+            size_t col_offset = global.col_offset(*this)+1;
+
+            //So the global row idx of row (in the global grid) would be
+            size_t global_row_idx = row+row_offset;
+
+            //And the col idx of col (in the global grid) would be
+            size_t global_col_idx = col+col_offset;
+            //So the global cell number is
+            return global_row_idx * global.cols() + global_col_idx;
         }
 
     private:

--- a/src/output_writer.h
+++ b/src/output_writer.h
@@ -11,11 +11,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @file output_writer.h
+ * @version 0.1
+ * @date 2022-03-24
+ * 
+ * Changelog:
+ *  version 0.1
+ *      Nels Frazier (nfrazier@lynker.com) added write_coverage
+ * 
+ */
 #ifndef EXACTEXTRACT_OUTPUT_WRITER_H
 #define EXACTEXTRACT_OUTPUT_WRITER_H
 
 #include <string>
 #include <vector>
+#include "raster.h"
 
 namespace exactextract {
 
@@ -24,6 +35,15 @@ namespace exactextract {
 
     class OutputWriter {
     public:
+
+        /**
+         * @brief Allows writing of coverage fraction independently
+         * 
+         * @param fid Feature id the coverage fraction relates to
+         * @param raster The raster the features is covering, used to identify cell number
+         * @param common_grid The common grid used to map row and column indicies to coverage fraction
+         */
+        virtual void write_coverage(const std::string & fid, const Raster<float> & raster, const Grid<bounded_extent> & common_grid) = 0;
         virtual void write(const std::string & fid) = 0;
         virtual void add_operation(const Operation & op) = 0;
         virtual void set_registry(const StatsRegistry* reg) = 0;

--- a/src/raster_sequential_processor.h
+++ b/src/raster_sequential_processor.h
@@ -11,6 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @file raster_sequential_processor.h
+ * @version 0.1
+ * @date 2022-03-24
+ * 
+ * Changelog:
+ *  version 0.1
+ *      Nels Frazier (nfrazier@lynker.com) make feature_tree protected so it can be accessed by subclasses
+ * 
+ */
+
 #include <memory>
 
 #ifndef EXACTEXTRACT_RASTER_SEQUENTIAL_PROCESSOR_H
@@ -31,11 +42,13 @@ namespace exactextract {
 
         void process() override;
 
-    private:
+    protected:
         using Feature=std::pair<std::string, geom_ptr_r>;
+        tree_ptr_r m_feature_tree{geos_ptr(m_geos_context, GEOSSTRtree_create_r(m_geos_context, 10))};
+
+    private:
 
         std::vector<Feature> m_features;
-        tree_ptr_r m_feature_tree{geos_ptr(m_geos_context, GEOSSTRtree_create_r(m_geos_context, 10))};
     };
 
 }

--- a/src/raster_stats.h
+++ b/src/raster_stats.h
@@ -11,6 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @file raster_stats.h
+ * @version 0.1
+ * @date 2022-03-24
+ * 
+ * Changelog:
+ *  version 0.1
+ *      Nels Frazier (nfrazier@lynker.com) cache m_ci
+ *      Nels Frazier (nfrazier@lynker.com) add a private grid_meta struct
+ *      Nels Frazier (nfrazier@lynker.com) store the coverage fraction info when processed
+ *      Nels Frazier (nfrazier@lynker.com) add coverage_fraction and cell_number "stat" functions to expose the cached grid meta data
+ * 
+ */
+
 #ifndef EXACTEXTRACT_RASTER_STATS_H
 #define EXACTEXTRACT_RASTER_STATS_H
 
@@ -160,6 +174,28 @@ namespace exactextract {
                 entry.m_sum_ciwi += ciwi;
                 m_quantiles.reset();
             }
+        }
+        
+        /**
+         * The percent of the cell covered by this polygon
+         */
+        std::vector<double> coverage_fraction() const {
+            return m_grid_meta.pct_cov;
+        }
+
+        /*
+        * The cell number of the raster the stat was extracted from
+        */
+        std::vector<double> cell_number (Grid<bounded_extent> global = Grid<bounded_extent>::make_empty() ) const {
+            std::vector<double> out(m_grid_meta.pct_cov.size());
+            for(size_t i = 0; i < m_grid_meta.pct_cov.size(); i++){
+                size_t cell_number = m_grid_meta.grid.map_to_grid_cell(m_grid_meta.rows[i], m_grid_meta.cols[i], global);
+                //THIS CAST isn't a good idea for large values of size_t
+                //but is a bit of a currrent limitation of the result_fetcher
+                //in operation.  Should probably template that...
+                out[i] = cell_number;
+            }
+            return out;
         }
 
         /**

--- a/src/raster_stats.h
+++ b/src/raster_stats.h
@@ -39,6 +39,7 @@ namespace exactextract {
         explicit RasterStats(bool store_values = false) :
                 m_min{std::numeric_limits<T>::max()},
                 m_max{std::numeric_limits<T>::lowest()},
+                m_ci{0},
                 m_sum_ciwi{0},
                 m_sum_ci{0},
                 m_sum_xici{0},
@@ -111,12 +112,13 @@ namespace exactextract {
         }
 
         void process_value(const T& val, float coverage, double weight) {
-            m_sum_ci += static_cast<double>(coverage);
-            m_sum_xici += val*static_cast<double>(coverage);
+            m_ci = static_cast<double>(coverage);
+            m_sum_ci += m_ci;
+            m_sum_xici += val*m_ci;
 
             m_variance.process(val, coverage);
 
-            double ciwi = static_cast<double>(coverage)*weight;
+            double ciwi = m_ci*weight;
             m_sum_ciwi += ciwi;
             m_sum_xiciwi += val * ciwi;
 
@@ -132,7 +134,7 @@ namespace exactextract {
 
             if (m_store_values) {
                 auto& entry = m_freq[val];
-                entry.m_sum_ci += static_cast<double>(coverage);
+                entry.m_sum_ci += m_ci;
                 entry.m_sum_ciwi += ciwi;
                 m_quantiles.reset();
             }
@@ -419,6 +421,7 @@ namespace exactextract {
         T m_max;
 
         // ci: coverage fraction of pixel i
+        double m_ci;
         // wi: weight of pixel i
         // xi: value of pixel i
         double m_sum_ciwi;

--- a/src/raster_stats.h
+++ b/src/raster_stats.h
@@ -417,9 +417,18 @@ namespace exactextract {
         }
 
     private:
+        struct grid_meta{
+            std::vector<size_t> rows;
+            std::vector<size_t> cols;
+            std::vector<double> pct_cov;
+            Grid<bounded_extent> grid;
+            grid_meta():rows{}, cols{}, pct_cov{}, grid(Grid<bounded_extent>::make_empty()){}
+        };
+
         T m_min;
         T m_max;
 
+        grid_meta m_grid_meta;
         // ci: coverage fraction of pixel i
         double m_ci;
         // wi: weight of pixel i


### PR DESCRIPTION
This PR introduces two mechanics for getting coverage fraction reports from the core lib -- it can be asked for as an operation alongside other stats, or from the CLI it can be provided as a strategy which will only write the coverage fraction and cell number.

Tests coverage was added to the catch tests for the coverage fraction.

Am happy to discuss any implementation details.