### PR TITLE
Add minimal Python bindings

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -10,38 +10,45 @@ jobs:
     strategy:
       matrix:
         ci:
-          - name: "GEOS 3.12, CLI"
+          - name: "GEOS 3.12, CLI, PYTHON"
             tag: geos312
             build_cli: YES
+            build_python: YES
 
           - name: "GEOS 3.11"
             tag: geos311
             build_cli: NO
+            build_python: NO
 
           - name: "GEOS 3.10"
             tag: geos310
             build_cli: NO
+            build_python: NO
 
           - name: "GEOS 3.9"
             tag: geos39
             build_cli: NO
+            build_python: NO
 
           - name: "GEOS 3.8"
             tag: geos38
             build_cli: NO
+            build_python: NO
 
           - name: "GEOS 3.7"
             tag: geos37
             build_cli: NO
+            build_python: NO
 
           - name: "GEOS 3.6"
             tag: geos36
             build_cli: NO
+            build_python: NO
 
           - name: "GEOS 3.5"
             tag: geos35
             build_cli: NO
-
+            build_python: NO
 
     name: ${{ matrix.ci.name }}
     runs-on: ubuntu-latest
@@ -54,7 +61,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Coverage -DBUILD_CLI=${{ matrix.ci.build_cli }} ..
+        cmake -DCMAKE_BUILD_TYPE=Coverage -DBUILD_CLI=${{ matrix.ci.build_cli }} -DBUILD_PYTHON=${{ matrix.ci.build_python }} ..
     - name: build
       run: |
         cd build
@@ -64,6 +71,7 @@ jobs:
         cd build
         valgrind --leak-check=full --error-exitcode=1 ./catch_tests
         if pytest --version; then pytest ../test; else echo "pytest not available"; fi
+        if [[ "${BUILD_PYTHON}" == "YES" ]] ; then ctest -R pybindings; fi
     - name: generate coverage report
       run: |
         cd build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ variables:
     - geos-config --version
     - mkdir build-coverage
     - cd build-coverage
-    - cmake -DCMAKE_BUILD_TYPE=Coverage -DBUILD_CLI=NO ..
+    - cmake -DCMAKE_BUILD_TYPE=Coverage -DBUILD_CLI=NO -DBUILD_PYTHON=NO ..
     - make -j2 catch_tests
     - valgrind --leak-check=full --error-exitcode=1 ./catch_tests
   after_script:
@@ -72,9 +72,25 @@ test:cli:
     - geos-config --version
     - mkdir build-coverage
     - cd build-coverage
-    - cmake -DCMAKE_BUILD_TYPE=Coverage -DBUILD_CLI=YES ..
+    - cmake -DCMAKE_BUILD_TYPE=Coverage -DBUILD_CLI=YES -DBUILD_PYTHON=NO ..
     - make -j2 exactextract_bin subdivide
     - pytest ../test
+  after_script:
+    - cd build-coverage
+    - lcov --capture --directory CMakeFiles --output-file coverage.info
+    - bash <(curl -s https://codecov.io/bash)
+
+test:python:
+  stage: test
+  image: isciences/exactextract-test-env:geos312
+  script:
+    - apt-get install -y python3-dev pybind11-dev
+    - geos-config --version
+    - mkdir build-coverage
+    - cd build-coverage
+    - cmake -DCMAKE_BUILD_TYPE=Coverage -DBUILD_CLI=NO -DBUILD_PYTHON=YES ..
+    - cmake --build . -j2
+    - ctest -R pybindings --output-on-failure
   after_script:
     - cd build-coverage
     - lcov --capture --directory CMakeFiles --output-file coverage.info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,8 @@ if(BUILD_TEST)
     # Create an executable to run the unit tests
     add_executable(catch_tests ${TEST_SOURCES})
 
+    add_test(NAME "catch_tests" COMMAND catch_tests)
+
     target_include_directories(
             catch_tests
             PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(BUILD_CLI)
     endif() #GDAL_FOUND
     if (NOT GDAL_FOUND)
         message(FATAL_ERROR
-        "GDAL version >= 2.0 was not found. It is still possible to build and test libexactextract, but the "
+        "GDAL version >= 2.0 was not found. It is still possible to build and test libexactextract using -DBUILD_CLI=NO, but the "
         "exactextract executable cannot be built or installed.")
     endif() #NOT GDAL_FOUND
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+
+include(CTest)
 include(GNUInstallDirs)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
@@ -19,6 +21,7 @@ find_package(GEOS REQUIRED)
 #Configure some options the various components this module can build
 option(BUILD_CLI "Build the exactextract cli binary" ON) #requires gdal, cli11
 option(BUILD_TEST "Build the exactextract tests" ON) #requires catch
+option(BUILD_PYTHON "Build the exactextract Python bindings" ON) # requires pybind11
 option(BUILD_DOC "Build documentation" ON) #requires doxygen
 
 if(BUILD_CLI)
@@ -246,6 +249,7 @@ set(PROJECT_SOURCES
 
 add_library(${LIB_NAME} ${PROJECT_SOURCES})
 
+
 # Check matrix bounds for debug builds
 set_target_properties(${LIB_NAME}
         PROPERTIES COMPILE_DEFINITIONS $<$<CONFIG:Debug>:MATRIX_CHECK_BOUNDS>)
@@ -276,6 +280,10 @@ target_link_libraries(
 )
 
 set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME ${LIB_NAME})
+
+if (BUILD_PYTHON)
+    add_subdirectory(python)
+endif() # BUILD_PYTHON
 
 if(BUILD_DOC)
     # Doxygen configuration from https://vicrucann.github.io/tutorials/quick-cmake-doxygen/

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Build the Python bindings, which require pybind11
+find_package(pybind11 REQUIRED)
+if (pybind11_FOUND)
+    # TODO: which pybind11 version
+endif() #pybind11_FOUND
+if (NOT pybind11_FOUND)
+    message(FATAL_ERROR
+    "pybind11 was not found. It is still possible to build and test libexactextract, but the "
+    "exactextract Python bindings cannot be built or installed.")
+endif() #NOT pybind11_FOUND
+
+
+set(PYBIND_SOURCES
+src/pybindings/bindings.cpp
+src/pybindings/feature_bindings.cpp
+src/pybindings/feature_bindings.h
+src/pybindings/feature_source_bindings.cpp
+src/pybindings/feature_source_bindings.h
+src/pybindings/operation_bindings.cpp
+src/pybindings/operation_bindings.h
+src/pybindings/processor_bindings.cpp
+src/pybindings/processor_bindings.h
+src/pybindings/raster_source_bindings.cpp
+src/pybindings/raster_source_bindings.h
+src/pybindings/writer_bindings.cpp
+src/pybindings/writer_bindings.h)
+
+pybind11_add_module(_exactextract MODULE ${PYBIND_SOURCES})
+target_include_directories(_exactextract PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${GEOS_INCLUDE_DIR})
+    set_property(TARGET ${LIB_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
+    target_link_libraries(_exactextract PRIVATE ${LIB_NAME} ${GEOS_LIBRARY})
+
+add_test(NAME "pybindings" 
+         COMMAND ${CMAKE_COMMAND} -E env
+         PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_CURRENT_LIST_DIR}/src
+         python3 -m pytest ${CMAKE_CURRENT_LIST_DIR}/tests)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,12 +1,11 @@
 # Build the Python bindings, which require pybind11
-find_package(pybind11 REQUIRED)
+find_package(pybind11 QUIET)
 if (pybind11_FOUND)
     # TODO: which pybind11 version
 endif() #pybind11_FOUND
 if (NOT pybind11_FOUND)
     message(FATAL_ERROR
-    "pybind11 was not found. It is still possible to build and test libexactextract, but the "
-    "exactextract Python bindings cannot be built or installed.")
+    "pybind11 was not found. It is still possible to build and test libexactextract using -DBUILD_PYTHON=NO.")
 endif() #NOT pybind11_FOUND
 
 

--- a/python/src/exactextract/__init__.py
+++ b/python/src/exactextract/__init__.py
@@ -4,7 +4,12 @@
 
 from .exact_extract import exact_extract
 from .feature import Feature, GDALFeature, JSONFeature
-from .feature_source import FeatureSource, GDALFeatureSource, JSONFeatureSource
+from .feature_source import (
+    FeatureSource,
+    GDALFeatureSource,
+    JSONFeatureSource,
+    GeoPandasFeatureSource,
+)
 from .operation import Operation
 from .processor import FeatureSequentialProcessor, RasterSequentialProcessor
 from .raster_source import RasterSource, GDALRasterSource, NumPyRasterSource

--- a/python/src/exactextract/__init__.py
+++ b/python/src/exactextract/__init__.py
@@ -12,5 +12,10 @@ from .feature_source import (
 )
 from .operation import Operation
 from .processor import FeatureSequentialProcessor, RasterSequentialProcessor
-from .raster_source import RasterSource, GDALRasterSource, NumPyRasterSource
+from .raster_source import (
+    RasterSource,
+    GDALRasterSource,
+    NumPyRasterSource,
+    RasterioRasterSource,
+)
 from .writer import Writer, JSONWriter, GDALWriter

--- a/python/src/exactextract/__init__.py
+++ b/python/src/exactextract/__init__.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """ Python bindings for exactextract """
 
+from .exact_extract import exact_extract
 from .feature import Feature, GDALFeature, JSONFeature
 from .feature_source import FeatureSource, GDALFeatureSource, JSONFeatureSource
 from .operation import Operation

--- a/python/src/exactextract/__init__.py
+++ b/python/src/exactextract/__init__.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+""" Python bindings for exactextract """
+
+from .feature import Feature, GDALFeature, JSONFeature
+from .feature_source import FeatureSource, GDALFeatureSource, JSONFeatureSource
+from .operation import Operation
+from .processor import FeatureSequentialProcessor, RasterSequentialProcessor
+from .raster_source import RasterSource, GDALRasterSource, NumPyRasterSource
+from .writer import Writer, JSONWriter, GDALWriter

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -6,7 +6,7 @@ from .writer import JSONWriter
 
 
 def prep_raster(rast):
-    # TODO add some hooks to allow RasterSource implementations 
+    # TODO add some hooks to allow RasterSource implementations
     # defined outside this library to handle other input types.
     if isinstance(rast, RasterSource):
         return rast
@@ -23,7 +23,7 @@ def prep_raster(rast):
 
 
 def prep_vec(vec):
-    # TODO add some hooks to allow FeatureSource implementations 
+    # TODO add some hooks to allow FeatureSource implementations
     # defined outside this library to handle other input types.
     if isinstance(vec, FeatureSource):
         return vec
@@ -61,12 +61,12 @@ def prep_processor(strategy):
     return processors[strategy]
 
 
-def exact_extract(rast, vec, ops, *, strategy="feature-sequential"):
+def exact_extract(rast, vec, ops, *, weights=None, strategy="feature-sequential"):
     rast = prep_raster(rast)
     vec = prep_vec(vec)
     # TODO: check CRS and transform if necessary/possible?
 
-    ops = prep_ops(ops, rast)
+    ops = prep_ops(ops, rast, weights)
 
     Processor = prep_processor(strategy)
 

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -1,0 +1,78 @@
+from .feature_source import FeatureSource, GDALFeatureSource, JSONFeatureSource
+from .raster_source import RasterSource, GDALRasterSource
+from .operation import Operation
+from .processor import FeatureSequentialProcessor, RasterSequentialProcessor
+from .writer import JSONWriter
+
+
+def prep_raster(rast):
+    # TODO add some hooks to allow RasterSource implementations 
+    # defined outside this library to handle other input types.
+    if isinstance(rast, RasterSource):
+        return rast
+
+    try:
+        from osgeo import gdal
+
+        if isinstance(rast, gdal.Dataset):
+            return GDALRasterSource(rast)
+    except ImportError:
+        pass
+
+    raise Exception("Unhandled raster datatype")
+
+
+def prep_vec(vec):
+    # TODO add some hooks to allow FeatureSource implementations 
+    # defined outside this library to handle other input types.
+    if isinstance(vec, FeatureSource):
+        return vec
+
+    try:
+        from osgeo import gdal, ogr
+
+        if isinstance(vec, gdal.Dataset) or isinstance(vec, ogr.DataSource):
+            return GDALFeatureSource(vec)
+    except ImportError:
+        pass
+
+    if type(vec) is list and len(vec) > 0 and "geometry" in vec[0]:
+        return JSONFeatureSource(vec, "id")
+
+    raise Exception("Unhandled feature datatype")
+
+
+def prep_ops(stats, value_rast, weights_rast=None):
+    if type(stats) is str:
+        stats = [stats]
+
+    # TODO derive names based on stat and value/weight names
+    ops = [Operation(stat, stat, value_rast, weights_rast) for stat in stats]
+
+    return ops
+
+
+def prep_processor(strategy):
+    processors = {
+        "feature-sequential": FeatureSequentialProcessor,
+        "raster-sequential": RasterSequentialProcessor,
+    }
+
+    return processors[strategy]
+
+
+def exact_extract(rast, vec, ops, *, strategy="feature-sequential"):
+    rast = prep_raster(rast)
+    vec = prep_vec(vec)
+    # TODO: check CRS and transform if necessary/possible?
+
+    ops = prep_ops(ops, rast)
+
+    Processor = prep_processor(strategy)
+
+    writer = JSONWriter()
+
+    processor = Processor(vec, writer, ops)
+    processor.process()
+
+    return writer.features()

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -164,7 +164,14 @@ def prep_processor(strategy):
 
 
 def exact_extract(
-    rast, vec, ops, *, weights=None, include_cols=None, strategy="feature-sequential"
+    rast,
+    vec,
+    ops,
+    *,
+    weights=None,
+    include_cols=None,
+    strategy="feature-sequential",
+    max_cells_in_memory=30000000,
 ):
     rast = prep_raster(rast, name_root="band")
     weights = prep_raster(weights, name_root="weight")
@@ -178,6 +185,7 @@ def exact_extract(
     writer = JSONWriter()
 
     processor = Processor(vec, writer, ops)
+    processor.set_max_cells_in_memory(max_cells_in_memory)
     if include_cols:
         for col in include_cols:
             processor.add_col(col)

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -90,7 +90,7 @@ def prep_processor(strategy):
     return processors[strategy]
 
 
-def exact_extract(rast, vec, ops, *, weights=None, strategy="feature-sequential"):
+def exact_extract(rast, vec, ops, *, weights=None, include_cols=None, strategy="feature-sequential"):
     rast = prep_raster(rast)
     vec = prep_vec(vec)
     # TODO: check CRS and transform if necessary/possible?
@@ -102,6 +102,9 @@ def exact_extract(rast, vec, ops, *, weights=None, strategy="feature-sequential"
     writer = JSONWriter()
 
     processor = Processor(vec, writer, ops)
+    if include_cols:
+        for col in include_cols:
+            processor.add_col(col)
     processor.process()
 
     return writer.features()

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -1,3 +1,5 @@
+import os
+
 from .feature_source import (
     FeatureSource,
     GDALFeatureSource,
@@ -25,6 +27,9 @@ def prep_raster(rast, band=None, name_root=None, names=None):
     try:
         from osgeo import gdal
 
+        if isinstance(rast, (str, os.PathLike)):
+            rast = gdal.Open(rast)
+
         if isinstance(rast, gdal.Dataset):
             if band:
                 return [GDALRasterSource(rast, band)]
@@ -40,6 +45,9 @@ def prep_raster(rast, band=None, name_root=None, names=None):
 
     try:
         import rasterio
+
+        if isinstance(rast, (str, os.PathLike)):
+            rast = rasterio.open(rast)
 
         if isinstance(rast, rasterio.DatasetReader):
             if band:
@@ -72,6 +80,9 @@ def prep_vec(vec):
     try:
         from osgeo import gdal, ogr
 
+        if isinstance(vec, (str, os.PathLike)):
+            vec = ogr.Open(vec)
+
         if isinstance(vec, gdal.Dataset) or isinstance(vec, ogr.DataSource):
             return GDALFeatureSource(vec)
     except ImportError:
@@ -79,6 +90,9 @@ def prep_vec(vec):
 
     try:
         import fiona
+
+        if isinstance(vec, (str, os.PathLike)):
+            vec = fiona.Open(vec)
 
         if isinstance(vec, fiona.Collection):
             return JSONFeatureSource(vec)

--- a/python/src/exactextract/feature.py
+++ b/python/src/exactextract/feature.py
@@ -1,0 +1,53 @@
+from _exactextract import Feature
+
+
+class GDALFeature(Feature):
+    def __init__(self, f):
+        Feature.__init__(self)
+        self.feature = f
+
+    def set(self, name, value):
+        self.feature.SetField(name, value)
+
+    def get(self, name):
+        return self.feature.GetField(name)
+
+    def geometry(self):
+        return bytes(self.feature.GetGeometryRef().ExportToWkb())
+
+    def fields(self):
+        defn = self.feature.GetDefnRef()
+        return [defn.GetFieldDefn(i).GetName() for i in range(defn.GetFieldCount())]
+
+
+class JSONFeature(Feature):
+    def __init__(self, f=None):
+        Feature.__init__(self)
+        self.feature = f or {}
+
+    def set(self, name, value):
+        if name == "id":
+            self.feature["id"] = value
+        else:
+            if "properties" not in self.feature:
+                self.feature["properties"] = {}
+            self.feature["properties"][name] = value
+
+    def get(self, name):
+        if name == "id":
+            return self.feature["id"]
+        else:
+            return self.feature["properties"][name]
+
+    def geometry(self):
+        import json
+
+        return json.dumps(self.feature["geometry"])
+
+    def fields(self):
+        fields = []
+        if "id" in self.feature:
+            fields.append("id")
+        if "properties" in self.feature:
+            fields += self.feature["properties"].keys()
+        return fields

--- a/python/src/exactextract/feature_source.py
+++ b/python/src/exactextract/feature_source.py
@@ -1,16 +1,25 @@
 from _exactextract import FeatureSource
 
+import os
+
 from .feature import GDALFeature, JSONFeature
 
 
 class GDALFeatureSource(FeatureSource):
     def __init__(self, src):
         super().__init__("")
+
+        if isinstance(src, (str, os.PathLike)):
+            from osgeo import ogr
+
+            src = ogr.Open(src)
+
         try:
             nlayers = src.GetLayerCount()
         except AttributeError:
             self.src = src
         else:
+            self.ds = src  # keep a reference to ds
             if nlayers > 1:
                 raise Exception(
                     "Can only process a single layer; call directly with ogr.Layer object."

--- a/python/src/exactextract/feature_source.py
+++ b/python/src/exactextract/feature_source.py
@@ -4,9 +4,19 @@ from .feature import GDALFeature, JSONFeature
 
 
 class GDALFeatureSource(FeatureSource):
-    def __init__(self, src, id_field):
-        super().__init__(id_field)
-        self.src = src
+    def __init__(self, src):
+        super().__init__("")
+        try:
+            nlayers = src.GetLayerCount()
+        except AttributeError:
+            self.src = src
+        else:
+            if nlayers > 1:
+                raise Exception(
+                    "Can only process a single layer; call directly with ogr.Layer object."
+                )
+
+            self.src = src.GetLayer(0)
 
     def __iter__(self):
         for f in self.src:
@@ -14,8 +24,8 @@ class GDALFeatureSource(FeatureSource):
 
 
 class JSONFeatureSource(FeatureSource):
-    def __init__(self, src, id_field):
-        super().__init__(id_field)
+    def __init__(self, src):
+        super().__init__("")
         if type(src) is dict:
             self.src = [src]
         else:
@@ -23,4 +33,14 @@ class JSONFeatureSource(FeatureSource):
 
     def __iter__(self):
         for f in self.src:
+            yield JSONFeature(f)
+
+
+class GeoPandasFeatureSource(FeatureSource):
+    def __init__(self, src):
+        super().__init__("")
+        self.src = src
+
+    def __iter__(self):
+        for f in self.src.iterfeatures():
             yield JSONFeature(f)

--- a/python/src/exactextract/feature_source.py
+++ b/python/src/exactextract/feature_source.py
@@ -1,0 +1,26 @@
+from _exactextract import FeatureSource
+
+from .feature import GDALFeature, JSONFeature
+
+
+class GDALFeatureSource(FeatureSource):
+    def __init__(self, src, id_field):
+        super().__init__(id_field)
+        self.src = src
+
+    def __iter__(self):
+        for f in self.src:
+            yield GDALFeature(f)
+
+
+class JSONFeatureSource(FeatureSource):
+    def __init__(self, src, id_field):
+        super().__init__(id_field)
+        if type(src) is dict:
+            self.src = [src]
+        else:
+            self.src = src
+
+    def __iter__(self):
+        for f in self.src:
+            yield JSONFeature(f)

--- a/python/src/exactextract/operation.py
+++ b/python/src/exactextract/operation.py
@@ -29,3 +29,4 @@ class Operation(_Operation):
             weights (Optional[RasterSource], optional): Weight raster to use. Defaults to None.
         """
         super().__init__(stat_name, field_name, raster, weights)
+        assert raster is not None

--- a/python/src/exactextract/operation.py
+++ b/python/src/exactextract/operation.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Optional
+
+from _exactextract import Operation as _Operation
+
+from .raster_source import RasterSource
+
+
+class Operation(_Operation):
+    """Binding class around exactextract Operation"""
+
+    def __init__(
+        self,
+        stat_name: str,
+        field_name: str,
+        raster: RasterSource,
+        weights: Optional[RasterSource] = None,
+    ):
+        """
+        Create Operation object from stat name, field name, raster, and weighted raster
+
+        Args:
+            stat_name (str): Name of the stat. Refer to docs for options.
+            field_name (str): Field name to use. Output of operation will have title \'{field_name}_{stat_name}\'
+            raster (RasterSource): Raster to compute over.
+            weights (Optional[RasterSource], optional): Weight raster to use. Defaults to None.
+        """
+        super().__init__(stat_name, field_name, raster, weights)

--- a/python/src/exactextract/processor.py
+++ b/python/src/exactextract/processor.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from typing import List, Union
+
+from _exactextract import (
+    FeatureSequentialProcessor as _FeatureSequentialProcessor,
+    RasterSequentialProcessor as _RasterSequentialProcessor,
+)
+
+from .feature_source import FeatureSource
+from .operation import Operation
+from .writer import Writer
+
+
+class FeatureSequentialProcessor(_FeatureSequentialProcessor):
+    """Binding class around exactextract FeatureSequentialProcessor"""
+
+    def __init__(self, ds: FeatureSource, writer: Writer, op_list: List[Operation]):
+        """
+        Create FeatureSequentialProcessor object
+
+        Args:
+            ds (FeatureSource): Dataset to use
+            writer (Writer): Writer to use
+            op_list (List[Operation]): List of operations
+        """
+        super().__init__(ds, writer)
+        for op in op_list:
+            self.add_operation(op)
+
+
+class RasterSequentialProcessor(_RasterSequentialProcessor):
+    """Binding class around exactextract RasterSequentialProcessor"""
+
+    def __init__(self, ds: FeatureSource, writer: Writer, op_list: List[Operation]):
+        """
+        Create RasterSequentialProcessor object
+
+        Args:
+            ds (FeatureSource): Dataset to use
+            writer (Writer): Writer to use
+            op_list (List[Operation]): List of operations
+        """
+        super().__init__(ds, writer)
+        for op in op_list:
+            self.add_operation(op)

--- a/python/src/exactextract/raster_source.py
+++ b/python/src/exactextract/raster_source.py
@@ -19,6 +19,11 @@ class GDALRasterSource(RasterSource):
         if band_idx is not None and band_idx <= 0:
             raise ValueError("Raster band index starts from 1!")
 
+        # Check for axis-aligned grid
+        gt = self.ds.GetGeoTransform()
+        if gt[2] != 0 or gt[4] != 0:
+            raise ValueError("Rotated rasters are not supported.")
+
         self.band = self.ds.GetRasterBand(band_idx)
 
         if name:
@@ -77,6 +82,10 @@ class RasterioRasterSource(RasterSource):
         super().__init__()
         self.ds = ds
         self.band_idx = band_idx
+
+        gt = self.ds.get_transform()
+        if gt[2] != 0 or gt[4] != 0:
+            raise ValueError("Rotated rasters are not supported.")
 
         if name:
             self.set_name(name)

--- a/python/src/exactextract/raster_source.py
+++ b/python/src/exactextract/raster_source.py
@@ -11,7 +11,7 @@ from _exactextract import RasterSource
 
 
 class GDALRasterSource(RasterSource):
-    def __init__(self, ds, band_idx: int = 1):
+    def __init__(self, ds, band_idx: int = 1, *, name=None):
         super().__init__()
         self.ds = ds
 
@@ -20,6 +20,9 @@ class GDALRasterSource(RasterSource):
             raise ValueError("Raster band index starts from 1!")
 
         self.band = self.ds.GetRasterBand(band_idx)
+
+        if name:
+            self.set_name(name)
 
     def res(self):
         gt = self.ds.GetGeoTransform()
@@ -42,7 +45,7 @@ class GDALRasterSource(RasterSource):
 
 
 class NumPyRasterSource(RasterSource):
-    def __init__(self, mat, xmin=None, ymin=None, xmax=None, ymax=None):
+    def __init__(self, mat, xmin=None, ymin=None, xmax=None, ymax=None, *, name=None):
         super().__init__()
         self.mat = mat
 
@@ -51,6 +54,9 @@ class NumPyRasterSource(RasterSource):
             self.ext = (0, 0, self.mat.shape[1], self.mat.shape[0])
         else:
             self.ext = (xmin, ymin, xmax, ymax)
+
+        if name:
+            self.set_name(name)
 
     def res(self):
         ny, nx = self.mat.shape
@@ -67,10 +73,13 @@ class NumPyRasterSource(RasterSource):
 
 
 class RasterioRasterSource(RasterSource):
-    def __init__(self, ds, band_idx=1):
+    def __init__(self, ds, band_idx=1, *, name=None):
         super().__init__()
         self.ds = ds
         self.band_idx = band_idx
+
+        if name:
+            self.set_name(name)
 
     def res(self):
         dx = (self.ds.bounds.right - self.ds.bounds.left) / self.ds.width

--- a/python/src/exactextract/raster_source.py
+++ b/python/src/exactextract/raster_source.py
@@ -64,3 +64,29 @@ class NumPyRasterSource(RasterSource):
 
     def read_window(self, x0, y0, nx, ny):
         return self.mat[y0 : y0 + ny, x0 : x0 + ny]
+
+
+class RasterioRasterSource(RasterSource):
+    def __init__(self, ds, band_idx=1):
+        super().__init__()
+        self.ds = ds
+        self.band_idx = band_idx
+
+    def res(self):
+        dx = (self.ds.bounds.right - self.ds.bounds.left) / self.ds.width
+        dy = (self.ds.bounds.top - self.ds.bounds.bottom) / self.ds.height
+
+        return (dx, dy)
+
+    def extent(self):
+        return (
+            self.ds.bounds.left,
+            self.ds.bounds.bottom,
+            self.ds.bounds.right,
+            self.ds.bounds.top,
+        )
+
+    def read_window(self, x0, y0, nx, ny):
+        from rasterio.windows import Window
+
+        return self.ds.read(self.band_idx, window=Window(x0, y0, nx, ny))

--- a/python/src/exactextract/raster_source.py
+++ b/python/src/exactextract/raster_source.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import pathlib
+from typing import Optional, Tuple, Union
+from osgeo import gdal
+
+from _exactextract import RasterSource
+
+
+class GDALRasterSource(RasterSource):
+    def __init__(self, ds, band_idx: int = 1):
+        super().__init__()
+        self.ds = ds
+
+        # Sanity check inputs
+        if band_idx is not None and band_idx <= 0:
+            raise ValueError("Raster band index starts from 1!")
+
+        self.band = self.ds.GetRasterBand(band_idx)
+
+    def res(self):
+        gt = self.ds.GetGeoTransform()
+        return gt[1], abs(gt[5])
+
+    def extent(self):
+        gt = self.ds.GetGeoTransform()
+
+        dx, dy = self.res()
+
+        left = gt[0]
+        right = left + dx * self.ds.RasterXSize
+        top = gt[3]
+        bottom = gt[3] - dy * self.ds.RasterYSize
+
+        return (left, bottom, right, top)
+
+    def read_window(self, x0, y0, nx, ny):
+        return self.band.ReadAsArray(xoff=x0, yoff=y0, win_xsize=nx, win_ysize=ny)
+
+
+class NumPyRasterSource(RasterSource):
+    def __init__(self, mat, xmin, ymin, xmax, ymax):
+        super().__init__()
+        self.mat = mat
+        self.ext = (xmin, ymin, xmax, ymax)
+
+    def res(self):
+        ny, nx = self.mat.shape
+        dy = (self.ext[3] - self.ext[1]) / ny
+        dx = (self.ext[2] - self.ext[0]) / nx
+
+        return (dx, dy)
+
+    def extent(self):
+        return self.ext
+
+    def read_window(self, x0, y0, nx, ny):
+        return self.mat[y0 : y0 + ny, x0 : x0 + ny]

--- a/python/src/exactextract/raster_source.py
+++ b/python/src/exactextract/raster_source.py
@@ -42,10 +42,15 @@ class GDALRasterSource(RasterSource):
 
 
 class NumPyRasterSource(RasterSource):
-    def __init__(self, mat, xmin, ymin, xmax, ymax):
+    def __init__(self, mat, xmin=None, ymin=None, xmax=None, ymax=None):
         super().__init__()
         self.mat = mat
-        self.ext = (xmin, ymin, xmax, ymax)
+
+        assert (xmin is None) == (ymin is None) == (xmax is None) == (ymax is None)
+        if xmin is None:
+            self.ext = (0, 0, self.mat.shape[1], self.mat.shape[0])
+        else:
+            self.ext = (xmin, ymin, xmax, ymax)
 
     def res(self):
         ny, nx = self.mat.shape

--- a/python/src/exactextract/writer.py
+++ b/python/src/exactextract/writer.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import pathlib
+from typing import Union, Dict, List
+
+from _exactextract import Writer
+from .feature import JSONFeature, GDALFeature
+
+
+class JSONWriter(Writer):
+    def __init__(self):
+        super().__init__()
+        self.feature_list = []
+
+    def write(self, feature):
+        f = JSONFeature()
+        feature.copy_to(f)
+        self.feature_list.append(f.feature)
+
+    def features(self):
+        return self.feature_list
+
+
+class GDALWriter(Writer):
+    def __init__(self, ds, name=""):
+        super().__init__()
+        self.feature_list = []
+        self.ds = ds
+        self.layer_name = name
+
+    def write(self, feature):
+        f = JSONFeature()
+        feature.copy_to(f)
+        self.feature_list.append(f)
+
+    def finish(self):
+        from osgeo import ogr
+
+        fields = self._collect_fields()
+
+        lyr = self.ds.CreateLayer(self.layer_name)
+        for field_def in fields.values():
+            lyr.CreateField(field_def)
+
+        for feature in self.feature_list:
+            ogr_feature = ogr.Feature(lyr.GetLayerDefn())
+            feature.copy_to(GDALFeature(ogr_feature))
+            lyr.CreateFeature(ogr_feature)
+
+    def _collect_fields(self):
+        from osgeo import ogr
+
+        ogr_fields = {}
+
+        for feature in self.feature_list:
+            for field_name in feature.fields():
+                if field_name not in ogr_fields:
+                    field_type = None
+
+                    value = feature.get(field_name)
+
+                    if type(value) is str:
+                        field_type = ogr.OFTString
+                    elif type(value) is float:
+                        field_type = ogr.OFTReal
+                    elif type(value) is type(value) is int:
+                        field_type = ogr.OFTInteger
+
+                    ogr_fields[field_name] = ogr.FieldDefn(field_name, field_type)
+
+        return ogr_fields

--- a/python/src/pybindings/bindings.cpp
+++ b/python/src/pybindings/bindings.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+#include "feature_bindings.h"
+#include "feature_source_bindings.h"
+#include "operation_bindings.h"
+#include "processor_bindings.h"
+#include "raster_source_bindings.h"
+#include "writer_bindings.h"
+
+namespace py = pybind11;
+
+namespace exactextract {
+PYBIND11_MODULE(_exactextract, m)
+{
+    bind_feature(m);
+    bind_feature_source(m);
+    bind_raster_source(m);
+    bind_operation(m);
+    bind_processor(m);
+    bind_writer(m);
+}
+}

--- a/python/src/pybindings/feature_bindings.cpp
+++ b/python/src/pybindings/feature_bindings.cpp
@@ -38,11 +38,6 @@ class PyFeatureBase : public Feature
     // plumbing to connect python-specifc abstract methods
     // to Feature abstract methods
 
-    float get_float(const std::string& name) const override
-    {
-        return get_py(name).cast<float>();
-    }
-
     double get_double(const std::string& name) const override
     {
         return get_py(name).cast<double>();
@@ -58,20 +53,9 @@ class PyFeatureBase : public Feature
         return get_py(name).cast<std::string>();
     }
 
-    void set(const std::string& name, std::size_t value) override
-    {
-        // TODO handle value > max python int
-        set_py(name, py::int_(value));
-    }
-
     void set(const std::string& name, std::string value) override
     {
         set_py(name, py::str(value));
-    }
-
-    void set(const std::string& name, float value) override
-    {
-        set_py(name, py::float_(value));
     }
 
     void set(const std::string& name, double value) override
@@ -197,7 +181,6 @@ bind_feature(py::module& m)
 
     py::class_<PyFeatureBase, Feature>(m, "PyFeatureBase")
       // debugging methods
-      .def("get_float", &PyFeature::get_float)
       .def("get_double", &PyFeature::get_double)
       .def("get_string", &PyFeature::get_string)
       .def("check", &PyFeatureBase::check);

--- a/python/src/pybindings/feature_bindings.cpp
+++ b/python/src/pybindings/feature_bindings.cpp
@@ -1,0 +1,212 @@
+// Copyright (c) 2023 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+
+#include "feature.h"
+#include "feature_bindings.h"
+
+namespace py = pybind11;
+
+namespace exactextract {
+class PyFeatureBase : public Feature
+{
+  public:
+    PyFeatureBase()
+    {
+        m_context = initGEOS_r(nullptr, nullptr);
+    }
+
+    virtual ~PyFeatureBase()
+    {
+        if (m_geom != nullptr) {
+            GEOSGeom_destroy_r(m_context, m_geom);
+        }
+    }
+
+    // plumbing to connect python-specifc abstract methods
+    // to Feature abstract methods
+
+    float get_float(const std::string& name) const override
+    {
+        return get_py(name).cast<float>();
+    }
+
+    double get_double(const std::string& name) const override
+    {
+        return get_py(name).cast<double>();
+    }
+
+    std::int32_t get_int(const std::string& name) const override
+    {
+        return get_py(name).cast<int32_t>();
+    }
+
+    std::string get_string(const std::string& name) const override
+    {
+        return get_py(name).cast<std::string>();
+    }
+
+    void set(const std::string& name, std::size_t value) override
+    {
+        // TODO handle value > max python int
+        set_py(name, py::int_(value));
+    }
+
+    void set(const std::string& name, std::string value) override
+    {
+        set_py(name, py::str(value));
+    }
+
+    void set(const std::string& name, float value) override
+    {
+        set_py(name, py::float_(value));
+    }
+
+    void set(const std::string& name, double value) override
+    {
+        set_py(name, py::float_(value));
+    }
+
+    void set(const std::string& name, std::int32_t value) override
+    {
+        set_py(name, py::int_(value));
+    }
+
+    const std::type_info& field_type(const std::string& name) const override
+    {
+        py::object value = get_py(name);
+
+        if (py::isinstance<py::int_>(value)) {
+            return typeid(int);
+        }
+
+        if (py::isinstance<py::float_>(value)) {
+            return typeid(double);
+        }
+
+        if (py::isinstance<py::str>(value)) {
+            return typeid(std::string);
+        }
+
+        throw std::runtime_error("Unhandled type for field " + name + " in PyFeatureBase::field_type");
+    }
+
+    const GEOSGeometry* geometry() const override
+    {
+        if (m_geom == nullptr) {
+            py::object geom = geometry_py();
+            if (py::isinstance<py::bytes>(geom)) {
+                py::buffer_info info = py::buffer(geom).request();
+                m_geom = GEOSGeomFromWKB_buf_r(m_context,
+                                               (const unsigned char*)info.ptr,
+                                               info.shape[0]);
+            } else if (py::isinstance<py::str>(geom)) {
+                std::string str = geom.cast<std::string>();
+                m_geom = GEOSGeomFromWKT_r(m_context, str.c_str());
+
+                if (m_geom == nullptr) {
+                    auto reader = GEOSGeoJSONReader_create_r(m_context);
+                    m_geom = GEOSGeoJSONReader_readGeometry_r(m_context, reader, str.c_str());
+                    GEOSGeoJSONReader_destroy_r(m_context, reader);
+                }
+            }
+
+            if (m_geom == nullptr) {
+                throw std::runtime_error("Failed to parse geometry.");
+            }
+        }
+
+        return m_geom;
+    }
+
+    void copy_to(Feature& other) const override
+    {
+        py::iterable field_list = fields();
+        for (py::handle field : field_list) {
+            std::string field_name = field.cast<std::string>();
+
+            other.set(field_name, *this);
+        }
+
+        // TODO copy geometry
+    }
+
+    // abstract methods to be implemented in Python class
+
+    virtual py::object get_py(const std::string& name) const = 0;
+
+    virtual void set_py(const std::string& name, py::object value) = 0;
+
+    virtual py::object geometry_py() const = 0;
+
+    virtual py::object fields() const = 0;
+
+    // debugging
+
+    bool check()
+    {
+        return geometry() != nullptr;
+    }
+
+  private:
+    GEOSContextHandle_t m_context;
+    mutable GEOSGeometry* m_geom;
+};
+
+class PyFeature : public PyFeatureBase
+{
+  public:
+    py::object geometry_py() const override
+    {
+        PYBIND11_OVERRIDE_PURE_NAME(py::object, PyFeature, "geometry", geometry_py);
+    }
+
+    py::object get_py(const std::string& name) const override
+    {
+        PYBIND11_OVERRIDE_PURE_NAME(py::object, PyFeature, "get", get_py, name);
+    }
+
+    void set_py(const std::string& name, py::object value) override
+    {
+        PYBIND11_OVERRIDE_PURE_NAME(void, PyFeature, "set", set_py, name, value);
+    }
+
+    py::object fields() const override
+    {
+        PYBIND11_OVERRIDE_PURE(py::object, PyFeature, fields);
+    }
+};
+
+void
+bind_feature(py::module& m)
+{
+    py::class_<Feature>(m, "FeatureBase")
+      .def("copy_to", &Feature::copy_to);
+
+    py::class_<PyFeatureBase, Feature>(m, "PyFeatureBase")
+      // debugging methods
+      .def("get_float", &PyFeature::get_float)
+      .def("get_double", &PyFeature::get_double)
+      .def("get_string", &PyFeature::get_string)
+      .def("check", &PyFeatureBase::check);
+
+    py::class_<PyFeature, PyFeatureBase, Feature>(m, "Feature")
+      .def(py::init<>())
+      .def("geometry", &PyFeature::geometry_py)
+      .def("get", &PyFeature::get_py)
+      .def("set", &PyFeature::set_py)
+      .def("fields", &PyFeature::fields);
+}
+}

--- a/python/src/pybindings/feature_bindings.cpp
+++ b/python/src/pybindings/feature_bindings.cpp
@@ -23,9 +23,8 @@ namespace exactextract {
 class PyFeatureBase : public Feature
 {
   public:
-    PyFeatureBase()
+    PyFeatureBase() : m_context(initGEOS_r(nullptr, nullptr)), m_geom(nullptr)
     {
-        m_context = initGEOS_r(nullptr, nullptr);
     }
 
     virtual ~PyFeatureBase()

--- a/python/src/pybindings/feature_bindings.h
+++ b/python/src/pybindings/feature_bindings.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace exactextract {
+void
+bind_feature(py::module& m);
+}

--- a/python/src/pybindings/feature_source_bindings.cpp
+++ b/python/src/pybindings/feature_source_bindings.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2023 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+
+#include "feature.h"
+#include "feature_source.h"
+#include "feature_source_bindings.h"
+
+namespace py = pybind11;
+
+namespace exactextract {
+class PyFeatureSourceBase : public FeatureSource
+{
+  public:
+    PyFeatureSourceBase(const std::string& id_field)
+      : m_id_field(id_field)
+      , m_initialized(false)
+    {
+    }
+
+    bool next() override
+    {
+        if (!m_initialized) {
+            m_it = py_iter();
+            m_initialized = true;
+        }
+
+        auto iter = py::iter(m_it);
+        if (iter == py::iterator::sentinel()) {
+            return false;
+        }
+        m_feature = py::cast<py::object>(*iter);
+        return true;
+    }
+
+    const Feature& feature() const override
+    {
+        return m_feature.cast<const Feature&>();
+    }
+
+    const std::string& id_field() const override
+    {
+        return m_id_field;
+    }
+
+    virtual py::object py_iter() = 0;
+
+    // debug
+    std::size_t count()
+    {
+        std::size_t i = 0;
+        while (next()) {
+            i++;
+        }
+        return i;
+    }
+
+  private:
+    std::string m_id_field;
+    py::object m_src;
+    py::object m_feature;
+    py::iterator m_it;
+    bool m_initialized;
+};
+
+class PyFeatureSource : public PyFeatureSourceBase
+{
+
+  public:
+    using PyFeatureSourceBase::PyFeatureSourceBase;
+
+    py::object py_iter() override
+    {
+        PYBIND11_OVERRIDE_PURE_NAME(py::object, PyFeatureSource, "__iter__", py_iter);
+    }
+};
+
+void
+bind_feature_source(py::module& m)
+{
+    py::class_<FeatureSource>(m, "FeatureSourceBase");
+
+    py::class_<PyFeatureSourceBase>(m, "PyFeatureSourceBase");
+
+    py::class_<PyFeatureSource, PyFeatureSourceBase, FeatureSource>(m, "FeatureSource")
+      .def(py::init<const std::string&>())
+      .def("__iter__", &PyFeatureSourceBase::py_iter)
+      // debug
+      .def("feature", &PyFeatureSourceBase::feature)
+      .def("count", &PyFeatureSourceBase::count);
+}
+}

--- a/python/src/pybindings/feature_source_bindings.h
+++ b/python/src/pybindings/feature_source_bindings.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace exactextract {
+void
+bind_feature_source(py::module& m);
+}

--- a/python/src/pybindings/operation_bindings.cpp
+++ b/python/src/pybindings/operation_bindings.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+#include "operation.h"
+#include "operation_bindings.h"
+#include "raster_source.h"
+
+namespace py = pybind11;
+
+namespace exactextract {
+void
+bind_operation(py::module& m)
+{
+    py::class_<Operation>(m, "Operation")
+      .def(py::init<std::string, std::string, RasterSource*, RasterSource*>())
+      .def("weighted", &Operation::weighted)
+      .def("grid", &Operation::grid)
+      .def_readonly("stat", &Operation::stat)
+      .def_readonly("name", &Operation::name)
+      .def_readonly("values", &Operation::values)
+      .def_readonly("weights", &Operation::weights);
+}
+}

--- a/python/src/pybindings/operation_bindings.h
+++ b/python/src/pybindings/operation_bindings.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace exactextract {
+void
+bind_operation(py::module& m);
+}

--- a/python/src/pybindings/processor_bindings.cpp
+++ b/python/src/pybindings/processor_bindings.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "feature_sequential_processor.h"
+#include "feature_source.h"
+#include "output_writer.h"
+#include "processor.h"
+#include "processor_bindings.h"
+#include "raster_sequential_processor.h"
+
+namespace py = pybind11;
+
+namespace exactextract {
+void
+bind_processor(py::module& m)
+{
+    py::class_<Processor>(m, "Processor")
+      .def("add_operation", &Processor::add_operation)
+      .def("process", &Processor::process)
+      .def("set_max_cells_in_memory", &Processor::set_max_cells_in_memory, py::arg("n"))
+      .def("show_progress", &Processor::show_progress, py::arg("val"));
+
+    py::class_<FeatureSequentialProcessor, Processor>(m, "FeatureSequentialProcessor")
+      .def(py::init<FeatureSource&, OutputWriter&>());
+
+    py::class_<RasterSequentialProcessor, Processor>(m, "RasterSequentialProcessor")
+      .def(py::init<FeatureSource&, OutputWriter&>());
+}
+}

--- a/python/src/pybindings/processor_bindings.cpp
+++ b/python/src/pybindings/processor_bindings.cpp
@@ -29,6 +29,7 @@ bind_processor(py::module& m)
 {
     py::class_<Processor>(m, "Processor")
       .def("add_operation", &Processor::add_operation)
+      .def("add_col", &Processor::include_col)
       .def("process", &Processor::process)
       .def("set_max_cells_in_memory", &Processor::set_max_cells_in_memory, py::arg("n"))
       .def("show_progress", &Processor::show_progress, py::arg("val"));

--- a/python/src/pybindings/processor_bindings.h
+++ b/python/src/pybindings/processor_bindings.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace exactextract {
+void
+bind_processor(py::module& m);
+}

--- a/python/src/pybindings/raster_source_bindings.cpp
+++ b/python/src/pybindings/raster_source_bindings.cpp
@@ -1,0 +1,140 @@
+// Copyright (c) 2023 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <utility>
+
+#include "raster_source.h"
+#include "raster_source_bindings.h"
+
+namespace py = pybind11;
+
+namespace exactextract {
+template<typename T>
+class NumPyRaster : public AbstractRaster<T>
+{
+  public:
+    using Unchecked2DArrayProxy = decltype(std::declval<py::array_t<T>>().template unchecked<2>());
+
+    NumPyRaster(py::array_t<T, py::array::c_style | py::array::forcecast> array,
+                const Grid<bounded_extent>& g)
+      : AbstractRaster<T>(g)
+      , m_array(array)
+      , m_array_proxy(array.template unchecked<2>())
+    {
+    }
+
+    T operator()(std::size_t row, std::size_t col) const override
+    {
+        return m_array_proxy(row, col);
+    }
+
+  private:
+    py::array_t<T> m_array;
+    Unchecked2DArrayProxy m_array_proxy;
+};
+
+class PyRasterSourceBase : public RasterSource
+{
+
+  public:
+    std::unique_ptr<AbstractRaster<double>> read_box(const Box& box) override
+    {
+        auto cropped_grid = grid().crop(box);
+
+        if (!cropped_grid.empty()) {
+            auto x0 = cropped_grid.col_offset(grid());
+            auto y0 = cropped_grid.row_offset(grid());
+            auto nx = cropped_grid.cols();
+            auto ny = cropped_grid.rows();
+
+            py::array rast_values = read_window(x0, y0, nx, ny);
+            return std::make_unique<NumPyRaster<double>>(rast_values, cropped_grid);
+        }
+
+        return nullptr;
+    }
+
+    const Grid<bounded_extent>& grid() const override
+    {
+        if (m_grid == nullptr) {
+            py::sequence grid_ext = extent();
+
+            if (grid_ext.size() != 4) {
+                throw std::runtime_error("Expected 4 elements in extent");
+            }
+
+            py::sequence grid_res = res();
+
+            if (grid_res.size() != 2) {
+                throw std::runtime_error("Expected 2 elements in resolution");
+            }
+
+            Box b{ grid_ext[0].cast<double>(), grid_ext[1].cast<double>(), grid_ext[2].cast<double>(), grid_ext[3].cast<double>() };
+
+            double dx = grid_res[0].cast<double>();
+            double dy = grid_res[1].cast<double>();
+
+            m_grid = std::make_unique<Grid<bounded_extent>>(b, dx, dy);
+        }
+
+        return *m_grid;
+    }
+
+    virtual py::array read_window(int x0, int y0, int nx, int ny) const = 0;
+
+    virtual py::object extent() const = 0;
+
+    virtual py::object res() const = 0;
+
+  private:
+    mutable std::unique_ptr<Grid<bounded_extent>> m_grid;
+};
+
+class PyRasterSource : public PyRasterSourceBase
+{
+
+  public:
+    py::object extent() const override
+    {
+        PYBIND11_OVERRIDE_PURE(py::tuple, PyRasterSource, extent);
+    }
+
+    py::object res() const override
+    {
+        PYBIND11_OVERRIDE_PURE(py::object, PyRasterSource, res);
+    }
+
+    py::array read_window(int x0, int y0, int nx, int ny) const override
+    {
+        PYBIND11_OVERRIDE_PURE(py::array, PyRasterSource, read_window, x0, y0, nx, ny);
+    }
+};
+
+void
+bind_raster_source(py::module& m)
+{
+    py::class_<RasterSource>(m, "RasterSourceBase")
+      .def("set_name", &RasterSource::set_name, py::arg("name"))
+      .def("name", &RasterSource::name);
+
+    py::class_<PyRasterSourceBase>(m, "PyRasterSourceBase");
+
+    py::class_<PyRasterSource, PyRasterSourceBase, RasterSource>(m, "RasterSource")
+      .def(py::init<>())
+      .def("extent", &PyRasterSource::extent)
+      .def("res", &PyRasterSource::res)
+      .def("read_window", &PyRasterSource::read_window);
+}
+}

--- a/python/src/pybindings/raster_source_bindings.h
+++ b/python/src/pybindings/raster_source_bindings.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace exactextract {
+void
+bind_raster_source(py::module& m);
+}

--- a/python/src/pybindings/writer_bindings.cpp
+++ b/python/src/pybindings/writer_bindings.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2023 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+#include "output_writer.h"
+#include "writer_bindings.h"
+
+namespace py = pybind11;
+
+namespace exactextract {
+class PyWriter : public OutputWriter
+{
+
+  public:
+    void write(const Feature& f) override
+    {
+        // https://github.com/pybind/pybind11/issues/2033#issuecomment-703177186
+        py::object dummy = py::cast(f, py::return_value_policy::reference);
+        PYBIND11_OVERLOAD_PURE(void, PyWriter, write, f);
+    }
+};
+
+void
+bind_writer(py::module& m)
+{
+    py::class_<OutputWriter, PyWriter>(m, "Writer")
+      .def(py::init<>())
+      .def("write", &OutputWriter::write);
+}
+}

--- a/python/src/pybindings/writer_bindings.h
+++ b/python/src/pybindings/writer_bindings.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 ISciences, LLC.
+// All rights reserved.
+//
+// This software is licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License. You may
+// obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace exactextract {
+void
+bind_writer(py::module& m);
+}

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,3 +1,2 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,34 @@
+import pytest
+
+from exactextract import NumPyRasterSource, JSONFeature
+
+
+@pytest.fixture()
+def np_raster_source():
+    np = pytest.importorskip("numpy")
+
+    mat = np.arange(100).reshape(10, 10)
+
+    return NumPyRasterSource(mat, 0, 0, 10, 10)
+
+
+@pytest.fixture()
+def square_features():
+    return [
+        {
+            "id": "0",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[0.5, 0.5], [2.5, 0.5], [2.5, 1.5], [0.5, 1.5], [0.5, 0.5]]
+                ],
+            },
+        },
+        {
+            "id": "1",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[4, 4], [5, 4], [5, 5], [4, 5], [4, 4]]],
+            },
+        },
+    ]

--- a/python/tests/test_exact_extract.py
+++ b/python/tests/test_exact_extract.py
@@ -12,7 +12,7 @@ def make_square_raster(n):
 
 def make_rect(xmin, ymin, xmax, ymax, fid=1):
     return {
-        "id": str(fid),
+        "id": fid,
         "geometry": {
             "type": "Polygon",
             "coordinates": [

--- a/python/tests/test_exact_extract.py
+++ b/python/tests/test_exact_extract.py
@@ -42,7 +42,7 @@ def make_rect(xmin, ymin, xmax, ymax, fid=1):
 )
 def test_basic_stats(stat, expected):
     rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))
-    square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5), "id")
+    square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5))
 
     assert exact_extract(rast, square, stat)[0]["properties"][stat] == pytest.approx(
         expected
@@ -51,7 +51,7 @@ def test_basic_stats(stat, expected):
 
 def test_multiple_stats():
     rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))
-    square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5), "id")
+    square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5))
 
     assert exact_extract(rast, square, ("min", "max", "mean"))[0]["properties"] == {
         "min": 1,
@@ -64,7 +64,7 @@ def test_multiple_stats():
 def test_weighted_stats_equal_weights(stat):
     rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))
     weights = NumPyRasterSource(np.full((3, 3), 1))
-    square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5), "id")
+    square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5))
 
     weighted_stat = f"weighted_{stat}"
 
@@ -87,7 +87,7 @@ def test_weighted_stats_equal_weights(stat):
 def test_weighted_stats_unequal_weights(stat, expected):
     rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))
     weights = NumPyRasterSource(np.array([[0, 0, 0], [0, 0, 0], [1, 1, 1]]))
-    square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5), "id")
+    square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5))
 
     assert exact_extract(rast, square, stat, weights=weights)[0]["properties"][
         stat
@@ -97,8 +97,7 @@ def test_weighted_stats_unequal_weights(stat, expected):
 def test_frac():
     rast = NumPyRasterSource(np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]]))
     squares = JSONFeatureSource(
-        [make_rect(0.5, 0.5, 1.0, 1.0, "a"), make_rect(0.5, 0.5, 2.5, 2.5, "b")], "id"
-    )
+        [make_rect(0.5, 0.5, 1.0, 1.0, "a"), make_rect(0.5, 0.5, 2.5, 2.5, "b")])
 
     results = exact_extract(rast, squares, ["count", "frac"])
 
@@ -123,8 +122,7 @@ def test_weighted_frac():
     rast = NumPyRasterSource(np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]]))
     weights = NumPyRasterSource(np.array([[3, 3, 3], [2, 2, 2], [1, 1, 1]]))
     squares = JSONFeatureSource(
-        [make_rect(0.5, 0.5, 1.0, 1.0, "a"), make_rect(0.5, 0.5, 2.5, 2.5, "b")], "id"
-    )
+        [make_rect(0.5, 0.5, 1.0, 1.0, "a"), make_rect(0.5, 0.5, 2.5, 2.5, "b")])
 
     results = exact_extract(rast, squares, ["weighted_frac", "sum"], weights=weights)
 
@@ -142,4 +140,147 @@ def test_weighted_frac():
         "sum": 8,
     }
 
-    pytest.xfail("missing placeholder results for wehgted_frac_1 and weighted_frac_2")
+    pytest.xfail("missing placeholder results for weighted_frac_1 and weighted_frac_2")
+
+
+
+def create_gdal_raster(fname, values):
+    gdal = pytest.importorskip("osgeo.gdal")
+    drv = gdal.GetDriverByName("GTiff")
+
+    ds = drv.Create(str(fname), values.shape[1], values.shape[0])
+    ds.SetGeoTransform((0.0, 1.0, 0.0, values.shape[0], 0.0, -1.0))
+    ds.WriteArray(values)
+
+
+def create_gdal_features(fname, features, name="test"):
+    gdal = pytest.importorskip("osgeo.gdal")
+
+    import tempfile
+    import json
+    with tempfile.NamedTemporaryFile(suffix=".geojson") as tf:
+        tf.write(json.dumps({
+            "type":"FeatureCollection",
+            "features": features
+        }).encode())
+        tf.flush()
+
+        ds = gdal.VectorTranslate(str(fname), tf.name)
+    
+
+def test_gdal_inputs(tmp_path):
+    gdal = pytest.importorskip("osgeo.gdal")
+    ogr = pytest.importorskip("osgeo.ogr")
+
+    raster_fname = str(tmp_path / "rast.tif")
+    create_gdal_raster(raster_fname, np.arange(1, 10).reshape(3, 3))
+
+    shp_fname = str(tmp_path / "geom.gpkg")
+    squares = [
+            make_rect(0.5, 0.5, 1.0, 1.0, "a"),
+            make_rect(0.5, 0.5, 2.5, 2.5, "b")]
+
+    create_gdal_features(shp_fname, squares)
+
+    rast = gdal.Open(raster_fname)
+    shp = ogr.Open(shp_fname)
+
+    results = exact_extract(rast, shp, ["mean", "count"])
+
+    assert len(results) == 2
+
+    assert results[0]['properties'] == {
+            'count' : 0.25, 
+            'mean' : 7.0
+    }
+
+    assert results[1]['properties'] == {
+            'count': 4.0,
+            'mean': 5.0
+    }
+
+
+def test_fiona_inputs(tmp_path):
+    fiona = pytest.importorskip("fiona")
+
+    rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))
+
+    shp_fname = str(tmp_path / "geom.gpkg")
+    squares = [
+            make_rect(0.5, 0.5, 1.0, 1.0, "a"),
+            make_rect(0.5, 0.5, 2.5, 2.5, "b")]
+    create_gdal_features(shp_fname, squares)
+
+    shp = fiona.open(shp_fname)
+
+    results = exact_extract(rast, shp, ["mean", "count"])
+
+    assert len(results) == 2
+
+    assert results[0]['properties'] == {
+            'count' : 0.25, 
+            'mean' : 7.0
+    }
+
+    assert results[1]['properties'] == {
+            'count': 4.0,
+            'mean': 5.0
+    }
+
+
+
+def test_geopandas_inputs(tmp_path):
+    gp = pytest.importorskip("geopandas")
+
+    rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))
+
+    shp_fname = str(tmp_path / "geom.gpkg")
+    squares = [
+            make_rect(0.5, 0.5, 1.0, 1.0, "a"),
+            make_rect(0.5, 0.5, 2.5, 2.5, "b")]
+    create_gdal_features(shp_fname, squares)
+    
+    shp = gp.read_file(shp_fname)
+
+    results = exact_extract(rast, shp, ["mean", "count"])
+
+    assert len(results) == 2
+
+    assert results[0]['properties'] == {
+            'count' : 0.25, 
+            'mean' : 7.0
+    }
+
+    assert results[1]['properties'] == {
+            'count': 4.0,
+            'mean': 5.0
+    }
+
+
+def test_rasterio_inputs(tmp_path):
+    rasterio = pytest.importorskip("rasterio")
+
+    raster_fname = str(tmp_path / "rast.tif")
+    create_gdal_raster(raster_fname, np.arange(1, 10).reshape(3, 3))
+
+    squares = [
+            make_rect(0.5, 0.5, 1.0, 1.0, "a"),
+            make_rect(0.5, 0.5, 2.5, 2.5, "b")]
+
+    rast = rasterio.open(raster_fname)
+    
+    results = exact_extract(rast, squares, ["mean", "count"])
+
+    assert len(results) == 2
+
+    assert results[0]['properties'] == {
+            'count' : 0.25, 
+            'mean' : 7.0
+    }
+
+    assert results[1]['properties'] == {
+            'count': 4.0,
+            'mean': 5.0
+    }
+
+

--- a/python/tests/test_exact_extract.py
+++ b/python/tests/test_exact_extract.py
@@ -37,11 +37,11 @@ def make_rect(xmin, ymin, xmax, ymax, fid=1):
         ("variety", 9),
         ("variance", 5),
         ("stdev", math.sqrt(5)),
-        ("coefficient_of_variation", math.sqrt(5)/5)
+        ("coefficient_of_variation", math.sqrt(5) / 5),
     ],
 )
-def test_exact_extract_stats(stat, expected):
-    rast = make_square_raster(3)
+def test_basic_stats(stat, expected):
+    rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))
     square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5), "id")
 
     assert exact_extract(rast, square, stat)[0]["properties"][stat] == pytest.approx(
@@ -49,8 +49,8 @@ def test_exact_extract_stats(stat, expected):
     )
 
 
-def test_exact_extract_multiple_stats():
-    rast = make_square_raster(3)
+def test_multiple_stats():
+    rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))
     square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5), "id")
 
     assert exact_extract(rast, square, ("min", "max", "mean"))[0]["properties"] == {
@@ -58,3 +58,88 @@ def test_exact_extract_multiple_stats():
         "max": 9,
         "mean": 5,
     }
+
+
+@pytest.mark.parametrize("stat", ("mean", "sum", "stdev", "variance"))
+def test_weighted_stats_equal_weights(stat):
+    rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))
+    weights = NumPyRasterSource(np.full((3, 3), 1))
+    square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5), "id")
+
+    weighted_stat = f"weighted_{stat}"
+
+    results = exact_extract(rast, square, [stat, weighted_stat], weights=weights)[0][
+        "properties"
+    ]
+
+    assert results[stat] == results[weighted_stat]
+
+
+@pytest.mark.parametrize(
+    "stat,expected",
+    [
+        ("weighted_mean", (0.25 * 7 + 0.5 * 8 + 0.25 * 9) / (0.25 + 0.5 + 0.25)),
+        ("weighted_sum", (0.25 * 7 + 0.5 * 8 + 0.25 * 9)),
+        ("weighted_stdev", 0.7071068),
+        ("weighted_variance", 0.5),
+    ],
+)
+def test_weighted_stats_unequal_weights(stat, expected):
+    rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))
+    weights = NumPyRasterSource(np.array([[0, 0, 0], [0, 0, 0], [1, 1, 1]]))
+    square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5), "id")
+
+    assert exact_extract(rast, square, stat, weights=weights)[0]["properties"][
+        stat
+    ] == pytest.approx(expected)
+
+
+def test_frac():
+    rast = NumPyRasterSource(np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]]))
+    squares = JSONFeatureSource(
+        [make_rect(0.5, 0.5, 1.0, 1.0, "a"), make_rect(0.5, 0.5, 2.5, 2.5, "b")], "id"
+    )
+
+    results = exact_extract(rast, squares, ["count", "frac"])
+
+    assert results[0]["properties"] == {
+        "count": 0.25,
+        # "frac_1" : 0,
+        # "frac_2" : 0,
+        "frac_3": 1.00,
+    }
+
+    assert results[1]["properties"] == {
+        "count": 4,
+        "frac_1": 0.25,
+        "frac_2": 0.5,
+        "frac_3": 0.25,
+    }
+
+    pytest.xfail("missing placeholder results for frac_1 and frac_2")
+
+
+def test_weighted_frac():
+    rast = NumPyRasterSource(np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]]))
+    weights = NumPyRasterSource(np.array([[3, 3, 3], [2, 2, 2], [1, 1, 1]]))
+    squares = JSONFeatureSource(
+        [make_rect(0.5, 0.5, 1.0, 1.0, "a"), make_rect(0.5, 0.5, 2.5, 2.5, "b")], "id"
+    )
+
+    results = exact_extract(rast, squares, ["weighted_frac", "sum"], weights=weights)
+
+    assert results[0]["properties"] == {
+        # "weighted_frac_1" : 0,
+        # "weighted_frac_2" : 0,
+        "weighted_frac_3": 1,
+        "sum": 0.75,
+    }
+
+    assert results[1]["properties"] == {
+        "weighted_frac_1": 0.375,
+        "weighted_frac_2": 0.5,
+        "weighted_frac_3": 0.125,
+        "sum": 8,
+    }
+
+    pytest.xfail("missing placeholder results for wehgted_frac_1 and weighted_frac_2")

--- a/python/tests/test_exact_extract.py
+++ b/python/tests/test_exact_extract.py
@@ -1,0 +1,60 @@
+import math
+import pytest
+import numpy as np
+
+from exactextract import *
+
+
+def make_square_raster(n):
+    values = np.arange(1, n * n + 1).reshape(n, n)
+    return NumPyRasterSource(values, 0, 0, n, n)
+
+
+def make_rect(xmin, ymin, xmax, ymax, fid=1):
+    return {
+        "id": str(fid),
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [[xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax], [xmin, ymin]]
+            ],
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "stat,expected",
+    [
+        ("count", 4),
+        ("mean", 5),
+        ("median", 5),
+        ("min", 1),
+        ("max", 9),
+        ("mode", 5),
+        ("majority", 5),
+        ("minority", 1),
+        # TODO: add quantiles
+        ("variety", 9),
+        ("variance", 5),
+        ("stdev", math.sqrt(5)),
+        ("coefficient_of_variation", math.sqrt(5)/5)
+    ],
+)
+def test_exact_extract_stats(stat, expected):
+    rast = make_square_raster(3)
+    square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5), "id")
+
+    assert exact_extract(rast, square, stat)[0]["properties"][stat] == pytest.approx(
+        expected
+    )
+
+
+def test_exact_extract_multiple_stats():
+    rast = make_square_raster(3)
+    square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5), "id")
+
+    assert exact_extract(rast, square, ("min", "max", "mean"))[0]["properties"] == {
+        "min": 1,
+        "max": 9,
+        "mean": 5,
+    }

--- a/python/tests/test_exact_extract.py
+++ b/python/tests/test_exact_extract.py
@@ -257,6 +257,27 @@ def test_weighted_multiband_weights():
     }
 
 
+def test_nodata():
+    data = np.arange(1, 101).reshape(10, 10)
+    data[6:10, 0:4] = -999  # flag lower-left corner as nodata
+    rast = NumPyRasterSource(data, nodata=-999)
+
+    # square entirely within nodata region
+    square = make_rect(0, 0, 3, 3)
+    results = exact_extract(rast, square, ["sum", "mean"])
+
+    assert results[0]["properties"] == pytest.approx(
+        {"sum": 0, "mean": float("nan")}, nan_ok=True
+    )
+
+    # square partially within nodata region
+    square = make_rect(3.5, 3.5, 4.5, 4.5)
+
+    results = exact_extract(rast, square, ["sum", "mean"])
+
+    assert results[0]["properties"] == {"sum": 43.5, "mean": 58}
+
+
 def create_gdal_raster(fname, values, *, gt=None):
     gdal = pytest.importorskip("osgeo.gdal")
     drv = gdal.GetDriverByName("GTiff")

--- a/python/tests/test_feature.py
+++ b/python/tests/test_feature.py
@@ -1,0 +1,63 @@
+import pytest
+
+from exactextract import Feature, GDALFeature, JSONFeature
+
+
+@pytest.fixture()
+def ogr_point():
+    from osgeo import ogr
+
+    fd = ogr.FeatureDefn()
+    fd.AddFieldDefn(ogr.FieldDefn("area", ogr.OFTReal))
+    fd.AddFieldDefn(ogr.FieldDefn("name", ogr.OFTString))
+
+    ogr_feature = ogr.Feature(fd)
+    ogr_feature["area"] = 33.6
+    ogr_feature["name"] = "test"
+    ogr_feature.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT (15 22)"))
+
+    return ogr_feature
+
+
+def test_gdal_feature(ogr_point):
+    f = GDALFeature(ogr_point)
+
+    assert isinstance(f, Feature)
+
+    assert f.check()
+
+    f.set("area", 12.2)
+
+    assert f.get("area") == 12.2
+    assert ogr_point["area"] == 12.2
+
+
+def test_json_feature():
+    f = JSONFeature(
+        {
+            "id": 17,
+            "properties": {"name": "Jay", "type": "q"},
+            "geometry": {"type": "Point", "coordinates": [-74, 44]},
+        }
+    )
+
+    assert isinstance(f, Feature)
+
+    assert f.check()
+
+    assert f.get("id") == 17
+    assert f.get("type") == "q"
+
+    f.set("id", 18)
+    f.set("type", "n")
+
+    assert f.get("id") == 18
+    assert f.get("type") == "n"
+
+
+def test_feature_copy_to(ogr_point):
+    f = JSONFeature()
+    GDALFeature(ogr_point).copy_to(f)
+
+    assert f.get("area") == 33.6
+    assert f.get("name") == "test"

--- a/python/tests/test_feature_source.py
+++ b/python/tests/test_feature_source.py
@@ -1,0 +1,43 @@
+import pytest
+
+from exactextract import GDALFeatureSource, JSONFeatureSource
+
+
+def test_gdal_feature_source():
+    from osgeo import ogr
+
+    drv = ogr.GetDriverByName("Memory")
+    ds = drv.CreateDataSource("")
+
+    assert ds is not None
+
+    lyr = ds.CreateLayer("test")
+    lyr.CreateField(ogr.FieldDefn("id", ogr.OFTInteger))
+
+    assert lyr is not None
+
+    feat = ogr.Feature(lyr.GetLayerDefn())
+    for i in range(5):
+        feat["id"] = i
+        lyr.CreateFeature(feat)
+
+    fs = GDALFeatureSource(lyr, "id")
+
+    assert fs.count() == 5
+
+
+def test_python_feature_source():
+    features = []
+
+    for i in range(5):
+        features.append(
+            {
+                "id": i,
+                "properties": {"name": f"feature_{i}"},
+                "geometry": {"type": "Point", "coordinates": [i, i]},
+            }
+        )
+
+    fs = JSONFeatureSource(features, "id")
+
+    assert fs.count() == 5

--- a/python/tests/test_feature_source.py
+++ b/python/tests/test_feature_source.py
@@ -21,7 +21,7 @@ def test_gdal_feature_source():
         feat["id"] = i
         lyr.CreateFeature(feat)
 
-    fs = GDALFeatureSource(lyr, "id")
+    fs = GDALFeatureSource(lyr)
 
     assert fs.count() == 5
 
@@ -38,6 +38,6 @@ def test_python_feature_source():
             }
         )
 
-    fs = JSONFeatureSource(features, "id")
+    fs = JSONFeatureSource(features)
 
     assert fs.count() == 5

--- a/python/tests/test_operation.py
+++ b/python/tests/test_operation.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from exactextract import Operation
+
+
+def test_valid_stat(np_raster_source):
+    valid_stats = (
+        "count",
+        "sum",
+        "mean",
+        "weighted_sum",
+        "weighted_mean",
+        "min",
+        "max",
+        "minority",
+        "majority",
+        "variety",
+        "variance",
+        "stdev",
+        "coefficient_of_variation",
+    )
+    for stat in valid_stats:
+        op = Operation(stat, "test", np_raster_source)
+        assert op.stat == stat
+
+
+def test_field_name(np_raster_source):
+    op = Operation("count", "any_field_name", np_raster_source)
+    assert op.name == "any_field_name"
+
+
+def test_valid_raster(np_raster_source):
+    op = Operation("count", "test", np_raster_source)
+    assert op.values == np_raster_source
+
+
+def test_invalid_raster():
+    with pytest.raises(TypeError):
+        Operation("count", "test", "invalid")  # type: ignore
+
+
+def test_valid_weights(np_raster_source):
+    rs1 = np_raster_source
+    rs2 = np_raster_source
+
+    op = Operation("count", "test", rs1, None)
+    assert op.values == rs2
+    assert op.weights is None
+
+    op = Operation("weighted_mean", "test", rs1, rs2)
+    assert op.values == rs1
+    assert op.weights == rs2
+
+
+def test_invalid_weights(np_raster_source):
+    with pytest.raises(TypeError):
+        Operation("count", "test", np_raster_source, "invalid")  # type: ignore

--- a/python/tests/test_operation.py
+++ b/python/tests/test_operation.py
@@ -11,8 +11,6 @@ def test_valid_stat(np_raster_source):
         "count",
         "sum",
         "mean",
-        "weighted_sum",
-        "weighted_mean",
         "min",
         "max",
         "minority",

--- a/python/tests/test_processor.py
+++ b/python/tests/test_processor.py
@@ -14,7 +14,7 @@ def test_process(Processor, np_raster_source, square_features):
     ]
     writer = JSONWriter()
 
-    fs = JSONFeatureSource(square_features, "id")
+    fs = JSONFeatureSource(square_features)
 
     processor = Processor(fs, writer, ops)
     processor.process()
@@ -25,4 +25,4 @@ def test_process(Processor, np_raster_source, square_features):
 
     f1 = results[0]
     assert f1["properties"].keys() == {"my_test", "test"}
-    assert f1["id"] == square_features[0]["id"]
+    #assert f1["id"] == square_features[0]["id"]

--- a/python/tests/test_processor.py
+++ b/python/tests/test_processor.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from exactextract import *
+
+
+@pytest.mark.parametrize("Processor", (FeatureSequentialProcessor,))
+def test_process(Processor, np_raster_source, square_features):
+    ops = [
+        Operation("count", "test", np_raster_source),
+        Operation("sum", "my_test", np_raster_source),
+    ]
+    writer = JSONWriter()
+
+    fs = JSONFeatureSource(square_features, "id")
+
+    processor = Processor(fs, writer, ops)
+    processor.process()
+
+    results = writer.features()
+
+    assert len(results) == len(square_features)
+
+    f1 = results[0]
+    assert f1["properties"].keys() == {"my_test", "test"}
+    assert f1["id"] == square_features[0]["id"]

--- a/python/tests/test_processor.py
+++ b/python/tests/test_processor.py
@@ -17,6 +17,7 @@ def test_process(Processor, np_raster_source, square_features):
     fs = JSONFeatureSource(square_features)
 
     processor = Processor(fs, writer, ops)
+    processor.add_col("id")
     processor.process()
 
     results = writer.features()
@@ -25,4 +26,4 @@ def test_process(Processor, np_raster_source, square_features):
 
     f1 = results[0]
     assert f1["properties"].keys() == {"my_test", "test"}
-    #assert f1["id"] == square_features[0]["id"]
+    assert f1["id"] == square_features[0]["id"]

--- a/python/tests/test_raster_source.py
+++ b/python/tests/test_raster_source.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from exactextract import GDALRasterSource
+
+
+@pytest.fixture()
+def global_half_degree(tmp_path):
+    from osgeo import gdal
+
+    fname = str(tmp_path / "test.tif")
+
+    drv = gdal.GetDriverByName("GTiff")
+    ds = drv.Create(fname, 720, 360)
+    gt = (-180.0, 0.5, 0.0, 90.0, 0.0, -0.5)
+    ds.SetGeoTransform(gt)
+    ds = None
+
+    return fname
+
+
+def test_gdal_raster(global_half_degree):
+    from osgeo import gdal
+
+    ds = gdal.Open(global_half_degree)
+
+    src = GDALRasterSource(ds, 1)
+
+    assert src.res() == (0.50, 0.50)
+    assert src.extent() == pytest.approx((-180, -90, 180, 90))
+
+    assert src.read_window(0, 0, 10, 10).shape == (10, 10)

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from exactextract import JSONFeature, GDALWriter, JSONWriter
+
+
+@pytest.fixture()
+def point_features():
+    return [
+        JSONFeature(
+            {
+                "id": 3,
+                "properties": {"type": "apple"},
+                "geometry": {"type": "Point", "coordinates": [3, 8]},
+            }
+        ),
+        JSONFeature(
+            {
+                "id": 2,
+                "properties": {"type": "pear"},
+                "geometry": {"type": "Point", "coordinates": [2, 2]},
+            }
+        ),
+    ]
+
+
+def test_json_writer(point_features):
+    w = JSONWriter()
+
+    for f in point_features:
+        w.write(f)
+
+    assert len(w.features()) == len(point_features)
+
+    f = w.features()[0]
+    assert f["id"] == 3
+    assert f["properties"]["type"] == "apple"
+
+    f = w.features()[1]
+    assert f["id"] == 2
+    assert f["properties"]["type"] == "pear"
+
+
+def test_gdal_writer(point_features):
+    from osgeo import ogr
+
+    drv = ogr.GetDriverByName("Memory")
+    ds = drv.CreateDataSource("")
+
+    w = GDALWriter(ds, "out")
+
+    for f in point_features:
+        w.write(f)
+    w.finish()
+
+    lyr = ds.GetLayerByName("out")
+    assert lyr is not None
+    assert lyr.GetFeatureCount() == len(point_features)
+
+    f = lyr.GetNextFeature()
+    assert f["id"] == 3
+    assert f["type"] == "apple"
+
+    f = lyr.GetNextFeature()
+    assert f["id"] == 2
+    assert f["type"] == "pear"

--- a/src/coverage_operation.h
+++ b/src/coverage_operation.h
@@ -71,7 +71,7 @@ class CoverageOperation : public Operation
         }
     }
 
-    virtual std::unique_ptr<Operation> clone() const {
+    std::unique_ptr<Operation> clone() const override {
         return std::make_unique<CoverageOperation>(*this);
     }
 
@@ -82,7 +82,7 @@ class CoverageOperation : public Operation
         m_last_coverage = last_coverage;
     }
 
-    virtual void set_result(const StatsRegistry& reg, const std::string& fid, Feature& f_out) const
+    void set_result(const StatsRegistry& reg, const Feature& fid, Feature& f_out) const override
     {
         (void)reg;
         (void)fid;

--- a/src/coverage_processor.cpp
+++ b/src/coverage_processor.cpp
@@ -43,9 +43,8 @@ CoverageProcessor::process()
 
     while (m_shp.next()) {
         const Feature& f_in = m_shp.feature();
-        std::string name = f_in.get_string(m_shp.id_field());
 
-        progress(name);
+        progress(f_in, m_shp.id_field());
 
         auto geom = f_in.geometry();
         auto feature_bbox = geos_get_box(m_geos_context, geom);
@@ -68,13 +67,13 @@ CoverageProcessor::process()
 
             for (const auto& loc : RasterCoverageIteration<double, double>(coverage_fractions, values, weights, grid, areas.get())) {
                 auto f_out = m_output.create_feature();
-                f_out->set(m_shp.id_field(), name);
+                f_out->set(m_shp.id_field(), f_in);
                 for (const auto& col: m_include_cols) {
                     f_out->set(col, f_in);
                 }
 
                 op.save_coverage(loc);
-                op.set_result(dummy, name, *f_out);
+                op.set_result(dummy, f_in, *f_out);
                 m_output.write(*f_out);
             }
 

--- a/src/coverage_processor.cpp
+++ b/src/coverage_processor.cpp
@@ -67,7 +67,9 @@ CoverageProcessor::process()
 
             for (const auto& loc : RasterCoverageIteration<double, double>(coverage_fractions, values, weights, grid, areas.get())) {
                 auto f_out = m_output.create_feature();
-                f_out->set(m_shp.id_field(), f_in);
+                if (m_shp.id_field() != "") {
+                    f_out->set(m_shp.id_field(), f_in);
+                }
                 for (const auto& col: m_include_cols) {
                     f_out->set(col, f_in);
                 }

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -13,6 +13,7 @@
 
 #include "feature.h"
 
+#include <limits>
 #include <stdexcept>
 
 namespace exactextract {
@@ -26,12 +27,35 @@ Feature::set(const std::string& name, const Feature& f)
         set(name, f.get_string(name));
     } else if (type == typeid(double)) {
         set(name, f.get_double(name));
-    } else if (type == typeid(float)) {
-        set(name, f.get_float(name));
     } else if (type == typeid(std::int32_t)) {
         set(name, f.get_int(name));
     } else if (type == typeid(std::size_t)) {
         set(name, f.get_int(name));
+    } else {
+        throw std::runtime_error("Unhandled type: " + std::string(type.name()));
+    }
+}
+
+void
+Feature::set(const std::string& name, std::size_t value)
+{
+    if (value > std::numeric_limits<std::int32_t>::max()) {
+        throw std::runtime_error("Value is too large to store as 32-bit integer.");
+    }
+    set(name, static_cast<std::int32_t>(value));
+}
+
+Feature::FieldValue
+Feature::get(const std::string& name) const
+{
+    const auto& type = field_type(name);
+
+    if (type == typeid(std::string)) {
+        return get_string(name);
+    } else if (type == typeid(double)) {
+        return get_double(name);
+    } else if (type == typeid(std::int32_t)) {
+        return get_int(name);
     } else {
         throw std::runtime_error("Unhandled type: " + std::string(type.name()));
     }

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -45,6 +45,12 @@ Feature::set(const std::string& name, std::size_t value)
     set(name, static_cast<std::int32_t>(value));
 }
 
+void
+Feature::set(const std::string& name, float value)
+{
+    set(name, static_cast<double>(value));
+}
+
 Feature::FieldValue
 Feature::get(const std::string& name) const
 {

--- a/src/feature.h
+++ b/src/feature.h
@@ -35,6 +35,7 @@ class Feature
     virtual void set(const std::string& name, double value) = 0;
     virtual void set(const std::string& name, std::int32_t value) = 0;
 
+    virtual void set(const std::string& name, float value);
     virtual void set(const std::string& name, std::size_t value);
     virtual void set(const std::string& name, const Feature& other);
 

--- a/src/feature.h
+++ b/src/feature.h
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <variant>
 #include <cstdint>
 #include <string>
 #include <typeinfo>
@@ -24,22 +25,23 @@ namespace exactextract {
 class Feature
 {
   public:
-    virtual ~Feature() {}
+    using FieldValue = std::variant<std::string, double, std::int32_t>;
 
-    virtual void set(const std::string& name, double value) = 0;
-    virtual void set(const std::string& name, float value) = 0;
-    virtual void set(const std::string& name, std::int32_t value) = 0;
-    virtual void set(const std::string& name, std::size_t value) = 0;
-    virtual void set(const std::string& name, std::string value) = 0;
+    virtual ~Feature() {}
 
     virtual const std::type_info& field_type(const std::string& name) const = 0;
 
+    virtual void set(const std::string& name, std::string value) = 0;
+    virtual void set(const std::string& name, double value) = 0;
+    virtual void set(const std::string& name, std::int32_t value) = 0;
+
+    virtual void set(const std::string& name, std::size_t value);
     virtual void set(const std::string& name, const Feature& other);
 
     virtual std::string get_string(const std::string& name) const = 0;
     virtual double get_double(const std::string& name) const = 0;
-    virtual float get_float(const std::string& name) const = 0;
     virtual std::int32_t get_int(const std::string& name) const = 0;
+    virtual FieldValue get(const std::string& name) const;
 
     virtual void copy_to(Feature& dst) const = 0;
 

--- a/src/feature_sequential_processor.cpp
+++ b/src/feature_sequential_processor.cpp
@@ -90,7 +90,9 @@ namespace exactextract {
             }
 
             auto f_out = m_output.create_feature();
-            f_out->set(m_shp.id_field(), f_in);
+            if (m_shp.id_field() != "") {
+                f_out->set(m_shp.id_field(), f_in);
+            }
             for (const auto& col: m_include_cols) {
                 f_out->set(col, f_in);
             }

--- a/src/feature_sequential_processor.cpp
+++ b/src/feature_sequential_processor.cpp
@@ -31,11 +31,10 @@ namespace exactextract {
 
         while (m_shp.next()) {
             const Feature& f_in = m_shp.feature();
-            std::string name = f_in.get_string(m_shp.id_field());
 
             auto geom = f_in.geometry();
 
-            progress(name);
+            progress(f_in, m_shp.id_field());
 
             Box feature_bbox = exactextract::geos_get_box(m_geos_context, geom);
 
@@ -80,9 +79,9 @@ namespace exactextract {
                         if (op->weighted()) {
                             auto weights = op->weights->read_box(subgrid.extent().intersection(op->weights->grid().extent()));
 
-                            m_reg.stats(name, *op, store_values).process(*coverage, *values, *weights);
+                            m_reg.stats(f_in, *op, store_values).process(*coverage, *values, *weights);
                         } else {
-                            m_reg.stats(name, *op, store_values).process(*coverage, *values);
+                            m_reg.stats(f_in, *op, store_values).process(*coverage, *values);
                         }
 
                         progress();
@@ -91,16 +90,16 @@ namespace exactextract {
             }
 
             auto f_out = m_output.create_feature();
-            f_out->set(m_shp.id_field(), f_in.get_string(m_shp.id_field()));
+            f_out->set(m_shp.id_field(), f_in);
             for (const auto& col: m_include_cols) {
                 f_out->set(col, f_in);
             }
             for (const auto& op : m_operations) {
-                op->set_result(m_reg, name, *f_out);
+                op->set_result(m_reg, f_in, *f_out);
             }
             m_output.write(*f_out);
 
-            m_reg.flush_feature(name);
+            m_reg.flush_feature(f_in);
         }
     }
 }

--- a/src/gdal_feature.h
+++ b/src/gdal_feature.h
@@ -101,11 +101,6 @@ class GDALFeature : public Feature
         OGR_F_SetFieldDouble(m_feature, field_index(name), value);
     }
 
-    void set(const std::string& name, float value) override
-    {
-        OGR_F_SetFieldDouble(m_feature, field_index(name), static_cast<double>(value));
-    }
-
     void set(const std::string& name, std::int32_t value) override
     {
         OGR_F_SetFieldInteger(m_feature, field_index(name), value);
@@ -130,10 +125,6 @@ class GDALFeature : public Feature
 
     double get_double(const std::string& name) const override {
         return OGR_F_GetFieldAsDouble(m_feature, field_index(name));
-    }
-
-    float get_float(const std::string& name) const override {
-        return static_cast<float>(OGR_F_GetFieldAsDouble(m_feature, field_index(name)));
     }
 
     std::int32_t get_int(const std::string& name) const override {

--- a/src/operation.h
+++ b/src/operation.h
@@ -24,6 +24,7 @@
 #include "raster_stats.h"
 #include "stats_registry.h"
 #include "raster_coverage_iterator.h"
+#include "utils.h"
 
 namespace exactextract {
 
@@ -48,6 +49,10 @@ namespace exactextract {
                 setQuantileFieldNames();
             } else {
                 m_field_names.push_back(name);
+            }
+
+            if (starts_with(stat, "weighted") && weights == nullptr) {
+                throw std::runtime_error("No weights provided for weighted stat: " + stat);
             }
 
             if (weighted()) {

--- a/src/operation.h
+++ b/src/operation.h
@@ -102,7 +102,9 @@ namespace exactextract {
 
 
         virtual void set_result(const StatsRegistry& reg, const Feature& f_in, Feature& f_out) const {
-            const RasterStats<double>& stats = reg.stats(f_in, *this);
+            static const RasterStats<double> empty_stats;
+
+            const RasterStats<double>& stats = reg.contains(f_in, *this) ? reg.stats(f_in, *this) : empty_stats;
 
             auto missing = std::numeric_limits<double>::quiet_NaN();
 

--- a/src/operation.h
+++ b/src/operation.h
@@ -96,8 +96,8 @@ namespace exactextract {
         }
 
 
-        virtual void set_result(const StatsRegistry& reg, const std::string& fid, Feature& f_out) const {
-            const RasterStats<double>& stats = reg.stats(fid, *this);
+        virtual void set_result(const StatsRegistry& reg, const Feature& f_in, Feature& f_out) const {
+            const RasterStats<double>& stats = reg.stats(f_in, *this);
 
             auto missing = std::numeric_limits<double>::quiet_NaN();
 

--- a/src/operation.h
+++ b/src/operation.h
@@ -123,8 +123,12 @@ namespace exactextract {
                 f_out.set(m_field_names[0], stats.variety());
             } else if (stat == "stdev") {
                 f_out.set(m_field_names[0], stats.stdev());
+            } else if (stat == "weighted_stdev") {
+                f_out.set(m_field_names[0], stats.weighted_stdev());
             } else if (stat == "variance") {
                 f_out.set(m_field_names[0], stats.variance());
+            } else if (stat == "weighted_variance") {
+                f_out.set(m_field_names[0], stats.weighted_variance());
             } else if (stat == "coefficient_of_variation") {
                 f_out.set(m_field_names[0], stats.coefficient_of_variation());
             } else if (stat == "median") {

--- a/src/processor.h
+++ b/src/processor.h
@@ -85,6 +85,16 @@ namespace exactextract {
                 std::cout << std::endl << "Processing " << name << std::flush;
         }
 
+        void progress(const Feature& f, const std::string& field) const {
+            if (m_show_progress) {
+                std::cout << std::endl << "Processing ";
+                std::visit([](auto&& value) {
+                    std::cout << value;
+                }, f.get(field));
+                std::cout << std::flush;
+            }
+        }
+
         void progress() const {
             if (m_show_progress)
                 std::cout << "." << std::flush;

--- a/src/raster_sequential_processor.cpp
+++ b/src/raster_sequential_processor.cpp
@@ -66,7 +66,6 @@ namespace exactextract {
             std::map<RasterSource*, std::unique_ptr<AbstractRaster<double>>> raster_values;
 
             for (const auto &f : hits) {
-                std::string fid = f->get_string(m_shp.id_field());
                 std::unique_ptr<Raster<float>> coverage;
                 std::set<std::pair<RasterSource*, RasterSource*>> processed;
 
@@ -108,9 +107,9 @@ namespace exactextract {
                             weights = raster_values[op->weights].get();
                         }
 
-                        m_reg.stats(fid, *op, store_values).process(*coverage, *values, *weights);
+                        m_reg.stats(*f, *op, store_values).process(*coverage, *values, *weights);
                     } else {
-                        m_reg.stats(fid, *op, store_values).process(*coverage, *values);
+                        m_reg.stats(*f, *op, store_values).process(*coverage, *values);
                     }
 
                     progress();
@@ -122,16 +121,15 @@ namespace exactextract {
 
         for (const auto& f_in : m_features) {
             auto f_out = m_output.create_feature();
-            std::string fid = f_in.get_string(m_shp.id_field());
-            f_out->set(m_shp.id_field(), fid);
+            f_out->set(m_shp.id_field(), f_in);
             for (const auto& col: m_include_cols) {
                 f_out->set(col, f_in);
             }
             for (const auto& op : m_operations) {
-                op->set_result(m_reg, fid, *f_out);
+                op->set_result(m_reg, f_in, *f_out);
             }
             m_output.write(*f_out);
-            m_reg.flush_feature(fid);
+            m_reg.flush_feature(f_in);
         }
     }
 

--- a/src/raster_sequential_processor.cpp
+++ b/src/raster_sequential_processor.cpp
@@ -121,7 +121,9 @@ namespace exactextract {
 
         for (const auto& f_in : m_features) {
             auto f_out = m_output.create_feature();
-            f_out->set(m_shp.id_field(), f_in);
+            if (m_shp.id_field() != "") {
+                f_out->set(m_shp.id_field(), f_in);
+            }
             for (const auto& col: m_include_cols) {
                 f_out->set(col, f_in);
             }

--- a/src/stats_registry.cpp
+++ b/src/stats_registry.cpp
@@ -19,11 +19,9 @@
 namespace exactextract {
 
 RasterStats<double>&
-StatsRegistry::stats(const std::string& feature, const Operation& op, bool store_values)
+StatsRegistry::stats(const Feature& feature, const Operation& op, bool store_values)
 {
-
-    // TODO come up with a better storage method.
-    auto& stats_for_feature = m_feature_stats[feature];
+    auto& stats_for_feature = m_feature_stats[&feature];
 
     // can't use find because this requires RasterStats to be copy-constructible before C++ 17
     auto exists = stats_for_feature.count(op.key());
@@ -37,11 +35,11 @@ StatsRegistry::stats(const std::string& feature, const Operation& op, bool store
 }
 
 bool
-StatsRegistry::contains(const std::string& feature, const Operation& op) const
+StatsRegistry::contains(const Feature& feature, const Operation& op) const
 {
     const auto& m = m_feature_stats;
 
-    auto it = m.find(feature);
+    auto it = m.find(&feature);
 
     if (it == m.end()) {
         return false;
@@ -53,10 +51,9 @@ StatsRegistry::contains(const std::string& feature, const Operation& op) const
 }
 
 const RasterStats<double>&
-StatsRegistry::stats(const std::string& feature, const Operation& op) const
+StatsRegistry::stats(const Feature& feature, const Operation& op) const
 {
-    // TODO come up with a better storage method.
-    return m_feature_stats.at(feature).at(op.key());
+    return m_feature_stats.at(&feature).at(op.key());
 }
 
 }

--- a/src/stats_registry.h
+++ b/src/stats_registry.h
@@ -21,6 +21,7 @@
 #include "raster_stats.h"
 
 namespace exactextract {
+    class Feature;
     class Operation;
 }
 
@@ -33,22 +34,22 @@ namespace exactextract {
     class StatsRegistry {
     public:
         /**
-         * @brief Get the RasterStats object for a given feature id/operation, creating it if necessary.
+         * @brief Get the RasterStats object for a given feature/operation, creating it if necessary.
          */
-        RasterStats<double> &stats(const std::string &feature, const Operation &op, bool store_values);
+        RasterStats<double> &stats(const Feature& feature, const Operation &op, bool store_values);
 
-        const RasterStats<double>& stats(const std::string &feature, const Operation &op) const;
+        const RasterStats<double>& stats(const Feature& feature, const Operation &op) const;
 
         /**
          * @brief Determine if a `RasterStats` object exists for a given feature id/operation
          */
-        bool contains(const std::string & feature, const Operation & op) const;
+        bool contains(const Feature& feature, const Operation & op) const;
 
         /**
          * @brief Remove RasterStats objects associated with a given feature id
          */
-        void flush_feature(const std::string &fid) {
-            m_feature_stats.erase(fid);
+        void flush_feature(const Feature& feature) {
+            m_feature_stats.erase(&feature);
         }
 
         static bool requires_stored_values(const std::string & stat) {
@@ -66,7 +67,7 @@ namespace exactextract {
 
     private:
 
-        std::unordered_map<std::string,
+        std::unordered_map<const Feature*,
         std::unordered_map<std::string, RasterStats <double>>> m_feature_stats{};
     };
 

--- a/test/test_operation.cpp
+++ b/test/test_operation.cpp
@@ -176,3 +176,16 @@ TEST_CASE("weighted_frac sets appropriate column names", "[operation]")
 
     CHECK_THROWS(f.get<double>("weighted_frac_9"));
 }
+
+TEST_CASE("error thrown if no weights provided for weighted operation", "[operation]")
+{
+    Grid<bounded_extent> ex{ { 0, 0, 3, 3 }, 1, 1 }; // 3x3 grid
+    Matrix<double> values{ { { 9, 1, 1 },
+                             { 2, 2, 2 },
+                             { 3, 3, 3 } } };
+
+    Raster<double> value_rast(std::move(values), ex.extent());
+    MemoryRasterSource<double> value_src(value_rast);
+
+    CHECK_THROWS( Operation("weighted_mean", "test", &value_src, nullptr) );
+}


### PR DESCRIPTION
I'm excited to have had some availability to work on the Python bindings. Talking to some users at FOSS4G-NA, I would say the enthusiasm for moving exactextract directly into the GDAL Python bindings was not universal -- there was more interest in using exactextract with other libraries like rasterio and xarray. So I decided to stick to the original plan and use pybind11. I began with the bindings put together by @jdalrym2 as a starting point and made the following changes:

- adapted to fit changes in internal interfaces (e.g., use of `Feature`)
- removed bindings for internal classes (`Cell`, `Coordinate`, etc.)
- removed bindings for GDAL-dependent classes (`GDALRasterWrapper`, etc.) so that we do not have GDAL as a build or runtime requirement
- added adapter classes to define `FeatureSource` and `RasterSource` objects in Python. As examples, the `GDALFeatureSource` and `GDALRasterSource` classes use the GDAL Python bindings to read vector and raster data. You can also stick an arbitrary NumPy array into a `NumPyRasterSource` and a list of GeoJSON features into a `JSONFeatureSource` if you're not using GDAL. It should be straightforward to write adapters for inputs associated with other common libraries.
- first steps at adding a high-level interface mimicking the one available in R (https://isciences.gitlab.io/exactextractr/reference/exact_extract.html)

Some components of @jdalrym2's effort are completely missing here, such as documentation and a `setup.py` configuration. There are clearly needed but I wanted to keep the scope of this PR manageable and, for documentation, I think it makes sense to let the interfaces settle down a bit first. In particular, I plan to implement support for efficiently processing multi-band rasters, like we have in `exactextractr`. It's possible that this will force some C++ API changes that impact Python bindings.

Because the commit history got messy, I've squashed the bindings work down to a single commit with me and @jdalrym2 as co-authors.
