### PR TITLE
Add several stat arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The area covered by the polygon is shaded purple.
 | min_center_x   | - | Cell center x-coordinate for the cell containing the minimum value intersected by the polygon. The center of this cell may or may not be inside the polygon. | Lowest point in watershed | 0.5 |
 | min_center_y   | - | Cell center y-coordinate for the cell containing the minimum value intersected by the polygon. The center of this cell may or may not be inside the polygon. | Lowest point in watershed | 1.5 |
 | minority       | -                                                                                    | The raster value occupying the least number of cells, taking into account cell coverage fractions but not weighting raster values. | Least common land cover type | 4 |
+| quantile       | - | Specified quantile of cells that intersect the polygon, weighted by the percent of each cell that is covered. Quantile value is specified by the `q` argument, 0 to 1. | - |
 | stdev          | &Sqrt;variance                                                                       | Population standard deviation of cell values that intersect the polygon, taking into account coverage fraction. | - | 1.05 |
 | sum            | &Sigma;x<sub>i</sub>c<sub>i</sub>                                                    | Sum of values of raster cells that intersect the polygon, with each raster value weighted by its coverage fraction. | Total population | 0.5&times;1 + 0&times;2 + 1.0&times;3 + 0.25&times;4 = 4.5 |
 | unique         |                                                                                      | Array of unique raster values for cells that intersect the polygon | - | [ 1, 3, 4 ] |
@@ -208,3 +209,15 @@ The area covered by the polygon is shaded purple.
 | weighted_sum   | &Sigma;x<sub>i</sub>c<sub>i</sub>w<sub>i</sub>                                       | Sum of raster cells covered by the polygon, with each raster value weighted by its coverage fraction and weighting raster value. | Total crop production lost | 0.5&times;1&times;5 + 0&times;2&times;6 + 1.0&times;3&times;7 + 0.25&times;4&times;8 = 31.5
 | weighted_variance |                                                                                   | Weighted version of `variance` | - |
 | weights        |                                                                                      | Array of weight values for each cell that intersects the polygon | - | [ 5, 7, 8 ] |
+
+The behavior of these statistics may be modified by the following arguments:
+
+- `coverage_weight` - specifies the value to use for ci in the above formulas. The following methods are available:
+   * `fraction` - the default method, with ci ranging from 0 to 1
+   * `none` - ci is always equal to 1; all pixels are given the same weight in the above calculations regardless of their coverage fraction
+   * `area_cartesian` - ci is the fraction of the pixel multiplied by it x and y resolutions
+   * `area_spherical_m2` - ci is the fraction of the pixel that is covered multiplied by a spherical approximation of the cell's area in square meters
+   * `area_spherical_km2` - ci is the fraction of the pixel that is covered multiplied by a spherical approximation of the cell's area in square kilometers
+- `default_value` - specifies a value to be used in place of NODATA
+- `default_weight` - specifies a weighing value to be used in place of NODATA
+- `min_coverage_frac` - specifies the minimum fraction of the pixel (0 to 1) that must be covered in order for a pixel to be considered in calculations. Defaults to 0.

--- a/python/src/pybindings/operation_bindings.cpp
+++ b/python/src/pybindings/operation_bindings.cpp
@@ -33,8 +33,9 @@ class PythonOperation : public Operation
                     std::string p_name,
                     RasterSource* p_values,
                     RasterSource* p_weights,
-                    bool call_with_weights)
-      : Operation("", p_name, p_values, p_weights)
+                    bool call_with_weights,
+                    Operation::ArgMap args = {})
+      : Operation("", p_name, p_values, p_weights, args)
       , m_function(fun)
       , m_call_with_weights(call_with_weights)
     {

--- a/src/measures.h
+++ b/src/measures.h
@@ -29,6 +29,12 @@ enum class AreaMethods
     SPHERICAL
 };
 
+enum class AreaUnit
+{
+    M2,
+    KM2
+};
+
 double
 area_signed(const std::vector<Coordinate>& ring);
 

--- a/src/operation.cpp
+++ b/src/operation.cpp
@@ -92,7 +92,11 @@ class OperationImpl : public Operation
         static_cast<Derived*>(this)->handle_options(options);
 
         if (!options.empty()) {
-            throw std::runtime_error("Unexpected argument(s) to stat: " + stat);
+            std::string msg = "Unexpected argument(s) to stat \"" + stat + "\": ";
+            for (const auto& [opt, _] : options) {
+                msg += opt + " ";
+            }
+            throw std::runtime_error(msg);
         }
 
         static_cast<Derived*>(this)->set_name(p_name);

--- a/src/operation.cpp
+++ b/src/operation.cpp
@@ -432,9 +432,15 @@ Operation::
     m_min_coverage = static_cast<float>(extract_arg<double>(options, "min_coverage_frac", 0.0));
     std::string coverage_type = extract_arg<std::string>(options, "coverage_weight", "fraction");
     if (coverage_type == "fraction") {
-        m_coverage_as_binary = false;
+        m_coverage_weight_type = CoverageWeightType::FRACTION;
     } else if (coverage_type == "none") {
-        m_coverage_as_binary = true;
+        m_coverage_weight_type = CoverageWeightType::NONE;
+    } else if (coverage_type == "area_spherical_m2") {
+        m_coverage_weight_type = CoverageWeightType::AREA_SPHERICAL_M2;
+    } else if (coverage_type == "area_spherical_km2") {
+        m_coverage_weight_type = CoverageWeightType::AREA_SPHERICAL_KM2;
+    } else if (coverage_type == "area_cartesian") {
+        m_coverage_weight_type = CoverageWeightType::AREA_CARTESIAN;
     } else {
         throw std::runtime_error("Unexpected coverage_weight type: " + coverage_type);
     }
@@ -447,7 +453,7 @@ Operation::
     ss << "values:" << values->name();
     ss << "|weights:" << (weights ? weights->name() : "");
     ss << "|mincov:" << m_min_coverage;
-    ss << "|fullpx:" << m_coverage_as_binary;
+    ss << "|covtyp:" << coverage_type;
     m_key = ss.str();
 }
 

--- a/src/operation.h
+++ b/src/operation.h
@@ -21,6 +21,7 @@
 #include "raster_source.h"
 #include "raster_stats.h"
 #include "stats_registry.h"
+#include "utils.h"
 
 namespace exactextract {
 /**
@@ -108,6 +109,21 @@ class Operation
         return m_min_coverage;
     }
 
+    template<typename T>
+    std::optional<T> default_value() const
+    {
+        if (!m_default_value.has_value()) {
+            return std::nullopt;
+        }
+
+        return { string::read<T>(m_default_value.value()) };
+    }
+
+    std::optional<double> default_weight() const
+    {
+        return m_default_weight;
+    }
+
     /// Returns the method by which pixel coverage should be considered in this `Operation`
     CoverageWeightType coverage_weight_type() const
     {
@@ -157,6 +173,9 @@ class Operation
     using missing_value_t = std::variant<float, double, std::int8_t, std::uint8_t, std::int16_t, std::uint16_t, std::int32_t, std::uint32_t, std::int64_t, std::uint64_t>;
 
     missing_value_t m_missing;
+
+    std::optional<std::string> m_default_value;
+    std::optional<double> m_default_weight;
 
     missing_value_t get_missing_value();
 

--- a/src/operation.h
+++ b/src/operation.h
@@ -101,7 +101,21 @@ class Operation
         return false;
     }
 
-    /// Returns a constructed `Grid` representing the common grid between
+    /// Return the minimum fraction of a pixel that must be covered for its value
+    /// to be considered in this `Operation`.
+    float min_coverage() const
+    {
+        return m_min_coverage;
+    }
+
+    /// Returns whether pixel covered fractions should be considered in this `Operation`,
+    /// or if calculations should equally weight all included pixels.
+    bool coverage_as_binary() const
+    {
+        return m_coverage_as_binary;
+    }
+
+    /// Returns a newly constructed `Grid` representing the common grid between
     /// the value and weighting rasters
     Grid<bounded_extent> grid() const;
 
@@ -136,7 +150,8 @@ class Operation
     Operation(std::string stat,
               std::string name,
               RasterSource* values,
-              RasterSource* weights = nullptr);
+              RasterSource* weights,
+              ArgMap& options);
 
     std::string m_key;
 
@@ -147,6 +162,9 @@ class Operation
     missing_value_t get_missing_value();
 
     const StatsRegistry::RasterStatsVariant& empty_stats() const;
+
+    float m_min_coverage;
+    bool m_coverage_as_binary;
 };
 
 }

--- a/src/operation.h
+++ b/src/operation.h
@@ -108,11 +108,10 @@ class Operation
         return m_min_coverage;
     }
 
-    /// Returns whether pixel covered fractions should be considered in this `Operation`,
-    /// or if calculations should equally weight all included pixels.
-    bool coverage_as_binary() const
+    /// Returns the method by which pixel coverage should be considered in this `Operation`
+    CoverageWeightType coverage_weight_type() const
     {
-        return m_coverage_as_binary;
+        return m_coverage_weight_type;
     }
 
     /// Returns a newly constructed `Grid` representing the common grid between
@@ -164,7 +163,7 @@ class Operation
     const StatsRegistry::RasterStatsVariant& empty_stats() const;
 
     float m_min_coverage;
-    bool m_coverage_as_binary;
+    CoverageWeightType m_coverage_weight_type;
 };
 
 }

--- a/src/raster.h
+++ b/src/raster.h
@@ -395,6 +395,25 @@ class RasterView : public AbstractRaster<T>
 };
 
 template<typename T>
+class ConstantRaster : public AbstractRaster<T>
+{
+  public:
+    ConstantRaster(const Grid<bounded_extent>& ex, T val)
+      : AbstractRaster<T>(ex)
+      , m_val(val)
+    {
+    }
+
+    T operator()(size_t, size_t) const override
+    {
+        return m_val;
+    }
+
+  private:
+    T m_val;
+};
+
+template<typename T>
 std::ostream&
 operator<<(std::ostream& os, const AbstractRaster<T>& m)
 {

--- a/src/raster.h
+++ b/src/raster.h
@@ -32,6 +32,7 @@ class AbstractRaster
       : m_grid{ ex }
       , m_nodata{ std::is_floating_point<T>::value ? std::numeric_limits<T>::quiet_NaN() : std::numeric_limits<T>::min() }
       , m_has_nodata{ false }
+      , m_mask{ nullptr }
     {
     }
 
@@ -39,6 +40,7 @@ class AbstractRaster
       : m_grid{ ex }
       , m_nodata{ nodata_val }
       , m_has_nodata{ true }
+      , m_mask{ nullptr }
     {
     }
 

--- a/src/raster_area.h
+++ b/src/raster_area.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 ISciences, LLC.
+// Copyright (c) 2021-2024 ISciences, LLC.
 // All rights reserved.
 //
 // This software is licensed under the Apache License, Version 2.0 (the "License").
@@ -11,9 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef EXACTEXTRACT_RASTER_AREA_H
-#define EXACTEXTRACT_RASTER_AREA_H
+#pragma once
 
+#include "measures.h"
 #include "raster.h"
 
 namespace exactextract {
@@ -42,7 +42,7 @@ template<typename T>
 class SphericalAreaRaster : public AbstractRaster<T>
 {
   public:
-    explicit SphericalAreaRaster(const Grid<bounded_extent>& ex)
+    explicit SphericalAreaRaster(const Grid<bounded_extent>& ex, AreaUnit unit)
       : AbstractRaster<T>(ex)
       , m_areas(ex.rows())
     {
@@ -51,12 +51,22 @@ class SphericalAreaRaster : public AbstractRaster<T>
         double dlon = g.dx();
         double dlat = g.dy();
 
+        double factor = 1;
+        switch (unit) {
+            case AreaUnit::M2:
+                factor = 1;
+                break;
+            case AreaUnit::KM2:
+                factor = 1e-6;
+                break;
+        }
+
         for (size_t i = 0; i < g.rows(); i++) {
             double y = g.y_for_row(i);
             double ymin = y - 0.5 * dlat;
             double ymax = y + 0.5 * dlat;
 
-            m_areas[i] = EARTH_RADIUS_SQ * PI_180 * std::abs(std::sin(ymin * PI_180) - std::sin(ymax * PI_180)) * dlon;
+            m_areas[i] = EARTH_RADIUS_SQ * PI_180 * std::abs(std::sin(ymin * PI_180) - std::sin(ymax * PI_180)) * dlon * factor;
         }
     }
 
@@ -74,5 +84,3 @@ class SphericalAreaRaster : public AbstractRaster<T>
     std::vector<double> m_areas;
 };
 }
-
-#endif // EXACTEXTRACT_RASTER_AREA_H

--- a/src/raster_sequential_processor.cpp
+++ b/src/raster_sequential_processor.cpp
@@ -69,15 +69,14 @@ RasterSequentialProcessor::process()
 
         for (const Feature* f : hits) {
             std::unique_ptr<Raster<float>> coverage;
-            std::set<std::pair<RasterSource*, RasterSource*>> processed;
+            std::set<std::string> processed;
 
             for (const auto& op : m_operations) {
                 // Avoid processing same values/weights for different stats
-                auto key = std::make_pair(op->weights, op->values);
-                if (processed.find(key) != processed.end()) {
+                if (processed.find(op->key()) != processed.end()) {
                     continue;
                 } else {
-                    processed.insert(key);
+                    processed.insert(op->key());
                 }
 
                 if (!op->values->grid().extent().contains(subgrid.extent())) {

--- a/src/stats_registry.cpp
+++ b/src/stats_registry.cpp
@@ -75,9 +75,13 @@ StatsRegistry::stats(const Feature& feature, const Operation& op)
         it = std::visit([&stats_for_feature, &op, this](const auto& r) {
                  using value_type = typename std::remove_reference_t<decltype(*r)>::value_type;
 
-                 RasterStatsOptions opts = m_stats_options;
+                 RasterStatsOptionsWithDefault<value_type> opts{ m_stats_options };
                  opts.min_coverage_fraction = op.min_coverage();
                  opts.weight_type = op.coverage_weight_type();
+                 if (op.default_weight().has_value()) {
+                     opts.default_weight = op.default_weight().value();
+                 }
+                 opts.default_value = op.default_value<value_type>();
 
                  return stats_for_feature.emplace(op.key(), RasterStats<value_type>(opts));
              },

--- a/src/stats_registry.cpp
+++ b/src/stats_registry.cpp
@@ -27,6 +27,8 @@ StatsRegistry::prepare(const Operation& op)
     m_stats_options.store_coverage_fraction |= op.requires_stored_coverage_fractions();
     m_stats_options.store_xy |= op.requires_stored_locations();
     m_stats_options.calc_variance |= op.requires_variance();
+    m_stats_options.coverage_as_binary |= op.coverage_as_binary();
+    m_stats_options.min_coverage_fraction = op.min_coverage();
 }
 
 void

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -319,4 +319,63 @@ prepare_operations(
 
     return ops;
 }
+
+namespace string {
+
+bool
+read_bool(const std::string& value)
+{
+    std::string value_lower = value;
+    for (auto& c : value_lower) {
+        c = std::tolower(c);
+    }
+
+    if (value_lower == "yes" || value_lower == "true") {
+        return true;
+    }
+    if (value_lower == "no" || value_lower == "false") {
+        return false;
+    }
+
+    throw std::runtime_error("Failed to parse value: " + value);
+}
+
+std::int64_t
+read_int64(const std::string& value)
+{
+    char* end = nullptr;
+    double d = std::strtol(value.data(), &end, 10);
+    if (end == value.data() + value.size()) {
+        return d;
+    }
+
+    throw std::runtime_error("Failed to parse value: " + value);
+}
+
+std::uint64_t
+read_uint64(const std::string& value)
+{
+    char* end = nullptr;
+    double d = std::strtoul(value.data(), &end, 10);
+    if (end == value.data() + value.size()) {
+        return d;
+    }
+
+    throw std::runtime_error("Failed to parse value: " + value);
+}
+
+double
+read_double(const std::string& value)
+{
+    char* end = nullptr;
+    double d = std::strtod(value.data(), &end);
+    if (end == value.data() + value.size()) {
+        return d;
+    }
+
+    throw std::runtime_error("Failed to parse value: " + value);
+}
+
+}
+
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -196,13 +196,21 @@ prepare_operations_implicit(
   const RasterSourceVect& values,
   const RasterSourceVect& weights)
 {
+    auto nvalues = values.size();
+    auto nweights = weights.size();
+    if (!starts_with(sd.stat, "weighted")) {
+        // Avoid looping over weights and generating duplicate Operations
+        // for an unweighted stat
+        nweights = std::min(nweights, 1ul);
+    }
+
     const bool full_names = values.size() > 1 || weights.size() > 1;
 
-    if (values.size() > 1 && weights.size() > 1 && values.size() != weights.size()) {
+    if (nvalues > 1 && nweights > 1 && nvalues != nweights) {
         throw std::runtime_error("Value and weight rasters must have a single band or the same number of bands.");
     }
 
-    std::size_t nops = std::max(values.size(), weights.size());
+    std::size_t nops = std::max(nvalues, nweights);
     for (std::size_t i = 0; i < nops; i++) {
         RasterSource* v = &*values[i % values.size()];
         RasterSource* w = weights.empty() ? nullptr : &*weights[i % weights.size()];

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -196,12 +196,12 @@ prepare_operations_implicit(
   const RasterSourceVect& values,
   const RasterSourceVect& weights)
 {
-    auto nvalues = values.size();
-    auto nweights = weights.size();
+    std::size_t nvalues = values.size();
+    std::size_t nweights = weights.size();
     if (!starts_with(sd.stat, "weighted")) {
         // Avoid looping over weights and generating duplicate Operations
         // for an unweighted stat
-        nweights = std::min(nweights, 1ul);
+        nweights = std::min(nweights, std::size_t{ 1 });
     }
 
     const bool full_names = values.size() > 1 || weights.size() > 1;

--- a/src/utils_cli.cpp
+++ b/src/utils_cli.cpp
@@ -31,7 +31,7 @@ load_gdal_rasters(const std::vector<std::string>& descriptors)
         auto [name, dsn, band] = exactextract::parse_raster_descriptor(descriptor);
 
         if (name.empty() && descriptors.size() > 1) {
-            name = std::filesystem::path(dsn).replace_extension("").filename();
+            name = std::filesystem::path(dsn).replace_extension("").filename().string();
         }
 
         std::shared_ptr<GDALRaster>& raster = rasters[dsn];

--- a/test/test_operation.cpp
+++ b/test/test_operation.cpp
@@ -400,4 +400,38 @@ TEST_CASE("Operation arguments", "[operation]")
         Operation::ArgMap args;
         CHECK_THROWS_WITH(Operation::create("quantile", "quantile", &mrs, nullptr, args), Catch::StartsWith("Missing required argument"));
     }
+
+    SECTION("error if default value out of range (int)")
+    {
+        Operation::ArgMap args{ { "default_value", "128" } };
+
+        auto op = Operation::create("sum", "sum", &mrs, nullptr, args);
+
+        CHECK_THROWS_WITH(op->default_value<std::int8_t>(), Catch::Contains("out of range"));
+    }
+
+    SECTION("error if default value out of range (float)")
+    {
+        Operation::ArgMap args{ { "default_value", "1e40" } };
+
+        auto op = Operation::create("sum", "sum", &mrs, nullptr, args);
+
+        CHECK_THROWS_WITH(op->default_value<float>(), Catch::Contains("out of range"));
+    }
+
+    SECTION("error if default value not parseable (int)")
+    {
+        Operation::ArgMap args{ { "default_value", "128k" } };
+
+        auto op = Operation::create("sum", "sum", &mrs, nullptr, args);
+
+        CHECK_THROWS_WITH(op->default_value<std::int32_t>(), Catch::Contains("Failed to parse value"));
+    }
+
+    SECTION("error if unknown coverage weight type")
+    {
+        Operation::ArgMap args{ { "coverage_weight", "method_that_does_not_exist" } };
+
+        CHECK_THROWS_WITH(Operation::create("sum", "sum", &mrs, nullptr, args), Catch::Contains("Unexpected coverage_weight type"));
+    }
 }

--- a/test/test_raster_area.cpp
+++ b/test/test_raster_area.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Spherical area raster returns pixel area")
 
     Grid<bounded_extent> g{ { 0, 45, 10, 55 }, dx, dy };
 
-    SphericalAreaRaster<double> areas(g);
+    SphericalAreaRaster<double> areas(g, AreaUnit::M2);
 
     // Compare to result from PostGIS, which is more accurate because
     // it is performing a geodesic calculation using geographiclib.

--- a/test/test_raster_cell_intersection.cpp
+++ b/test/test_raster_cell_intersection.cpp
@@ -511,6 +511,7 @@ TEST_CASE("Result indexing is correct", "[raster-cell-intersection]")
     CHECK(rci.data() == expected);
 }
 
+#ifndef _MSC_VER // error C2026: string too big
 TEST_CASE("Robustness regression test #1", "[raster-cell-intersection]")
 {
     // This test exercises some challenging behavior where a polygon follows
@@ -539,6 +540,7 @@ TEST_CASE("Robustness regression test #2", "[raster-cell-intersection]")
 
     CHECK_NOTHROW(RasterCellIntersection(ex, context, g.get()));
 }
+#endif
 
 TEST_CASE("Robustness regression test #3", "[raster-cell-intersection]")
 {
@@ -552,6 +554,7 @@ TEST_CASE("Robustness regression test #3", "[raster-cell-intersection]")
     CHECK_NOTHROW(raster_cell_intersection(ex, context, g.get()));
 }
 
+#ifndef _MSC_VER // error C2026: string too big
 TEST_CASE("Robustness regression test #4", "[raster-cell-intersection]")
 {
     GEOSContextHandle_t context = init_geos();
@@ -564,6 +567,7 @@ TEST_CASE("Robustness regression test #4", "[raster-cell-intersection]")
 
     CHECK_NOTHROW(raster_cell_intersection(ex, context, g.get()));
 }
+#endif
 
 TEST_CASE("Robustness regression test #5", "[raster-cell-intersection]")
 {

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -302,3 +302,50 @@ TEST_CASE("prepare_operations")
         CHECK(ops[1]->name == "adj_mean");
     }
 }
+
+TEST_CASE("parsing arguments")
+{
+    SECTION("int success")
+    {
+        CHECK(exactextract::string::read<std::uint32_t>(" 507") == 507);
+        CHECK(exactextract::string::read<std::uint32_t>("0") == 0);
+        CHECK(exactextract::string::read<std::int32_t>("-13") == -13);
+        CHECK(exactextract::string::read<std::uint64_t>("10000000000000000000") == 10000000000000000000ull);
+    }
+
+    SECTION("int failure")
+    {
+        CHECK_THROWS_WITH(exactextract::string::read<std::uint32_t>("507b"), Catch::Contains("Failed to parse"));
+    }
+
+    SECTION("int out of range")
+    {
+        CHECK_THROWS_WITH(exactextract::string::read<std::int8_t>("129"), Catch::Contains("out of range"));
+        CHECK_THROWS_WITH(exactextract::string::read<std::uint8_t>("-1"), Catch::Contains("out of range"));
+        CHECK_THROWS_WITH(exactextract::string::read<std::uint8_t>("256"), Catch::Contains("out of range"));
+    }
+
+    SECTION("float success")
+    {
+        CHECK(exactextract::string::read<float>(" 3.14e6") == 3.14e6f);
+        CHECK(exactextract::string::read<float>("0") == 0);
+    }
+
+    SECTION("float failure")
+    {
+        CHECK_THROWS_WITH(exactextract::string::read<float>(" 3.14e6g"), Catch::Contains("Failed to parse"));
+    }
+
+    SECTION("float out of range")
+    {
+        CHECK_THROWS_WITH(exactextract::string::read<float>("6.1e100"), Catch::Contains("out of range"));
+    }
+
+    SECTION("bool success")
+    {
+        CHECK(exactextract::string::read<bool>("YES"));
+        CHECK(exactextract::string::read<bool>("TRUE"));
+        CHECK(exactextract::string::read<bool>("No") == false);
+        CHECK(exactextract::string::read<bool>("False") == false);
+    }
+}

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -204,10 +204,10 @@ make_rasters(const std::string& prefix, std::size_t n)
 {
     std::vector<std::unique_ptr<RasterSource>> ret;
 
-    for (std::size_t i = 0; i < n; i++) {
+    for (std::size_t i = 1; i <= n; i++) {
         ret.emplace_back(std::make_unique<MemoryRasterSource>(
           RasterVariant(std::make_unique<Raster<float>>(Raster<float>::make_empty()))));
-        ret.back()->set_name(prefix + "_" + std::to_string(n));
+        ret.back()->set_name(prefix + std::to_string(i));
     }
 
     return ret;
@@ -215,7 +215,7 @@ make_rasters(const std::string& prefix, std::size_t n)
 
 TEST_CASE("prepare_operations")
 {
-    SECTION("values are recycled")
+    SECTION("weights are recycled")
     {
         auto values = make_rasters("v", 3);
         auto weights = make_rasters("w", 1);
@@ -228,9 +228,13 @@ TEST_CASE("prepare_operations")
             CHECK(ops[i]->values == values[i].get());
             CHECK(ops[i]->weights == weights[0].get());
         }
+
+        CHECK(ops[0]->name == "v1_w1_weighted_mean");
+        CHECK(ops[1]->name == "v2_w1_weighted_mean");
+        CHECK(ops[2]->name == "v3_w1_weighted_mean");
     }
 
-    SECTION("weights are recycled")
+    SECTION("values are recycled")
     {
         auto values = make_rasters("v", 1);
         auto weights = make_rasters("w", 3);
@@ -243,6 +247,10 @@ TEST_CASE("prepare_operations")
             CHECK(ops[i]->values == values[0].get());
             CHECK(ops[i]->weights == weights[i].get());
         }
+
+        CHECK(ops[0]->name == "v1_w1_weighted_mean");
+        CHECK(ops[1]->name == "v1_w2_weighted_mean");
+        CHECK(ops[2]->name == "v1_w3_weighted_mean");
     }
 
     SECTION("values and weights are paired bandwise")
@@ -258,6 +266,10 @@ TEST_CASE("prepare_operations")
             CHECK(ops[i]->values == values[i].get());
             CHECK(ops[i]->weights == weights[i].get());
         }
+
+        CHECK(ops[0]->name == "v1_w1_weighted_mean");
+        CHECK(ops[1]->name == "v2_w2_weighted_mean");
+        CHECK(ops[2]->name == "v3_w3_weighted_mean");
     }
 
     SECTION("values and weights have incompatible lengths")
@@ -268,5 +280,25 @@ TEST_CASE("prepare_operations")
 
         CHECK_THROWS_WITH(prepare_operations(stats, values, weights),
                           Catch::Contains("number of bands"));
+    }
+
+    SECTION("error when operation names are duplicated")
+    {
+        auto values = make_rasters("v", 1);
+        std::vector<std::unique_ptr<RasterSource>> weights;
+        std::vector<std::string> stats{ "mean", "mean(min_coverage_frac=0.25)" };
+
+        CHECK_THROWS_WITH(prepare_operations(stats, values, weights),
+                          Catch::Contains("name is not unique"));
+
+        // overriding a name solves the problem
+        stats = { "mean", "adj_mean=mean(min_coverage_frac=0.25)" };
+
+        auto ops = prepare_operations(stats, values, weights);
+
+        CHECK(ops.size() == 2);
+
+        CHECK(ops[0]->name == "mean");
+        CHECK(ops[1]->name == "adj_mean");
     }
 }


### PR DESCRIPTION
- `coverage_method` - specifies the value to use for ci in the above formulas. The following methods are available:
   * `fraction` - the default method, with ci ranging from 0 to 1
   * `none` - ci is always equal to 1; all pixels are given the same weight in the above calculations regardless of their coverage fraction
   * `area_cartesian` - ci is the fraction of the pixel multiplied by it x and y resolutions
   * `area_spherical_m2` - ci is the fraction of the pixel that is covered multiplied by a spherical approximation of the cell's area in square meters
   * `area_spherical_km2` - ci is the fraction of the pixel that is covered multiplied by a spherical approximation of the cell's area in square kilometers
- `default_value` - specifies a value to be used in place of NODATA
- `default_weight` - specifies a weighing value to be used in place of NODATA
- `min_coverage` - specifies the minimum fraction of the pixel (0 to 1) that must be covered in order for a pixel to be considered in calculations. Defaults to 0.
