### PR TITLE
Operation: refactor to use inheritance

### DIFF
--- a/python/src/pybindings/feature_bindings.cpp
+++ b/python/src/pybindings/feature_bindings.cpp
@@ -56,6 +56,11 @@ class PyFeatureBase : public Feature
         return get_py(name).cast<int32_t>();
     }
 
+    std::int64_t get_int64(const std::string& name) const override
+    {
+        return get_py(name).cast<int64_t>();
+    }
+
     IntegerArray get_integer_array(const std::string& name) const override
     {
         py::array_t<std::int32_t> arr = get_py(name);
@@ -76,6 +81,16 @@ class PyFeatureBase : public Feature
     void set(const std::string& name, std::string value) override
     {
         set_py(name, py::str(value));
+    }
+
+    void set(const std::string& name, std::int32_t value) override
+    {
+        set_py(name, py::int_(value));
+    }
+
+    void set(const std::string& name, std::int64_t value) override
+    {
+        set_py(name, py::int_(value));
     }
 
     void set(const std::string& name, double value) override
@@ -109,37 +124,32 @@ class PyFeatureBase : public Feature
         set_py(name, values);
     }
 
-    void set(const std::string& name, std::int32_t value) override
-    {
-        set_py(name, py::int_(value));
-    }
-
-    const std::type_info& field_type(const std::string& name) const override
+    ValueType field_type(const std::string& name) const override
     {
         py::object value = get_py(name);
 
         if (py::isinstance<py::int_>(value)) {
-            return typeid(int);
+            return ValueType::INT;
         }
 
         if (py::isinstance<py::float_>(value)) {
-            return typeid(double);
+            return ValueType::DOUBLE;
         }
 
         if (py::isinstance<py::str>(value)) {
-            return typeid(std::string);
+            return ValueType::STRING;
         }
 
         if (py::isinstance<py::array_t<double>>(value)) {
-            return typeid(DoubleArray);
+            return ValueType::DOUBLE;
         }
 
         if (py::isinstance<py::array_t<std::int32_t>>(value)) {
-            return typeid(IntegerArray);
+            return ValueType::INT_ARRAY;
         }
 
         if (py::isinstance<py::array_t<std::int64_t>>(value)) {
-            return typeid(Integer64Array);
+            return ValueType::INT64_ARRAY;
         }
 
         throw std::runtime_error("Unhandled type for field " + name + " in PyFeatureBase::field_type");

--- a/python/src/pybindings/operation_bindings.cpp
+++ b/python/src/pybindings/operation_bindings.cpp
@@ -26,9 +26,7 @@ void
 bind_operation(py::module& m)
 {
     py::class_<Operation>(m, "Operation")
-      .def(py::init<std::string, std::string, RasterSource*, RasterSource*, std::map<std::string, std::string>>())
-      .def_property_readonly("column_names_known", &Operation::column_names_known)
-      .def("field_names", &Operation::field_names)
+      .def(py::init(&Operation::create))
       .def("grid", &Operation::grid)
       .def("weighted", &Operation::weighted)
       .def_readonly("stat", &Operation::stat)

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -65,27 +65,7 @@ def test_gdal_writer(point_features):
     assert f["type"] == "pear"
 
 
-def test_pandas_writer_columns_discovered(point_features):
-    pd = pytest.importorskip("pandas")
-
-    w = PandasWriter()
-
-    for f in point_features:
-        w.write(f)
-    w.finish()
-
-    df = w.features()
-
-    assert isinstance(df, pd.DataFrame)
-    assert len(df) == 2
-
-    assert list(df.columns) == ["id", "type"]
-
-    assert list(df["id"]) == [3, 2]
-    assert list(df["type"]) == ["apple", "pear"]
-
-
-def test_pandas_writer_columns_declared(np_raster_source, point_features):
+def test_pandas_writer(np_raster_source, point_features):
     pd = pytest.importorskip("pandas")
 
     w = PandasWriter()
@@ -114,39 +94,3 @@ def test_pandas_writer_columns_declared(np_raster_source, point_features):
     assert list(df.columns) == ["id", "mean_result"]
     assert list(df["id"]) == [3, 2]
     assert list(df["mean_result"]) == [9, 4]
-
-
-def test_pandas_writer_columns_declared_and_discovered(
-    np_raster_source, point_features
-):
-    pd = pytest.importorskip("pandas")
-
-    w = PandasWriter()
-
-    w.add_column("id")
-    w.add_column("type")
-    w.add_operation(Operation("mean", "mean_result", np_raster_source))
-    w.add_operation(Operation("frac", "", np_raster_source))
-
-    point_features[0].feature["properties"]["mean_result"] = 9
-    point_features[0].feature["properties"]["frac_3"] = 3
-
-    point_features[1].feature["properties"]["mean_result"] = 4
-    point_features[1].feature["properties"]["frac_3"] = 33
-    point_features[1].feature["properties"]["frac_4"] = 44
-
-    for f in point_features:
-        w.write(f)
-
-    df = w.features()
-
-    assert isinstance(df, pd.DataFrame)
-    assert len(df) == 2
-
-    assert list(df.columns) == ["id", "type", "mean_result", "frac_3", "frac_4"]
-
-    assert list(df["id"]) == [3, 2]
-    assert list(df["type"]) == ["apple", "pear"]
-    assert list(df["mean_result"]) == [9, 4]
-    assert list(df["frac_3"]) == [3, 33]
-    assert list(df["frac_4"]) == pytest.approx([float("nan"), 44], abs=0, nan_ok=True)

--- a/src/deferred_gdal_writer.cpp
+++ b/src/deferred_gdal_writer.cpp
@@ -39,7 +39,7 @@ DeferredGDALWriter::finish()
             if (ogr_fields.find(field_name) == ogr_fields.end()) {
                 const auto& typ = feature.field_type(field_name);
 
-                if (typ == typeid(Feature::DoubleArray) || typ == typeid(Feature::IntegerArray) || typ == typeid(Feature::Integer64Array)) {
+                if (typ == Feature::ValueType::DOUBLE_ARRAY || typ == Feature::ValueType::INT_ARRAY || typ == Feature::ValueType::INT64_ARRAY) {
                     m_contains_nested_fields = true;
                 }
 

--- a/src/exactextract.cpp
+++ b/src/exactextract.cpp
@@ -103,16 +103,11 @@ main(int argc, char** argv)
         auto weights = exactextract::load_gdal_rasters(weight_descriptors);
 
         auto operations = prepare_operations(stats, rasters, weights);
-        const bool defer_writing = std::any_of(operations.begin(), operations.end(), [](const auto& op) { return !op->column_names_known(); });
 
         GDALDatasetWrapper shp = load_dataset(poly_descriptor, include_cols, src_id_name, dst_id_name, dst_id_type);
 
-        std::unique_ptr<exactextract::GDALWriter> gdal_writer = defer_writing
-                                                                  ? std::make_unique<
-                                                                      exactextract::DeferredGDALWriter>(
-                                                                      output_filename, !nested_output, shp.srs())
-                                                                  : std::make_unique<exactextract::GDALWriter>(
-                                                                      output_filename, !nested_output, shp.srs());
+        std::unique_ptr<exactextract::GDALWriter> gdal_writer = std::make_unique<exactextract::GDALWriter>(
+          output_filename, !nested_output, shp.srs());
 
         if (!dst_id_name.empty()) {
             include_cols.insert(include_cols.begin(), dst_id_name);

--- a/src/feature.cpp
+++ b/src/feature.cpp
@@ -23,40 +23,29 @@ namespace exactextract {
 void
 Feature::set(const std::string& name, const Feature& f)
 {
-    const auto& type = f.field_type(name);
-
-    if (type == typeid(std::string)) {
-        set(name, f.get_string(name));
-    } else if (type == typeid(double)) {
-        set(name, f.get_double(name));
-    } else if (type == typeid(DoubleArray)) {
-        set(name, f.get_double_array(name));
-    } else if (type == typeid(std::int8_t)) {
-        set(name, f.get_int(name));
-    } else if (type == typeid(std::int16_t)) {
-        set(name, f.get_int(name));
-    } else if (type == typeid(std::int32_t)) {
-        set(name, f.get_int(name));
-    } else if (type == typeid(IntegerArray)) {
-        set(name, f.get_integer_array(name));
-    } else if (type == typeid(std::int64_t)) {
-        set(name, f.get_int(name));
-    } else if (type == typeid(Integer64Array)) {
-        set(name, f.get_integer64_array(name));
-    } else if (type == typeid(std::size_t)) {
-        set(name, f.get_int(name));
-    } else {
-        throw std::runtime_error("Unhandled type: " + std::string(type.name()));
+    switch (f.field_type(name)) {
+        case ValueType::STRING:
+            set(name, f.get_string(name));
+            return;
+        case ValueType::DOUBLE:
+            set(name, f.get_double(name));
+            return;
+        case ValueType::DOUBLE_ARRAY:
+            set(name, f.get_double_array(name));
+            return;
+        case ValueType::INT:
+            set(name, f.get_int(name));
+            return;
+        case ValueType::INT64:
+            set(name, f.get_int64(name));
+            return;
+        case ValueType::INT_ARRAY:
+            set(name, f.get_integer_array(name));
+            return;
+        case ValueType::INT64_ARRAY:
+            set(name, f.get_integer64_array(name));
+            return;
     }
-}
-
-void
-Feature::set(const std::string& name, std::int64_t value)
-{
-    if (value > std::numeric_limits<std::int32_t>::max() || value < std::numeric_limits<std::int32_t>::min()) {
-        throw std::runtime_error("Value is too small/large to store as 32-bit integer.");
-    }
-    set(name, static_cast<std::int32_t>(value));
 }
 
 void
@@ -135,22 +124,24 @@ Feature::set(const std::string& name, const std::vector<double>& value)
 Feature::FieldValue
 Feature::get(const std::string& name) const
 {
-    const auto& type = field_type(name);
-
-    if (type == typeid(std::string)) {
-        return get_string(name);
-    } else if (type == typeid(double)) {
-        return get_double(name);
-    } else if (type == typeid(std::int32_t)) {
-        return get_int(name);
-    } else if (type == typeid(IntegerArray)) {
-        return get_integer_array(name);
-    } else if (type == typeid(Integer64Array)) {
-        return get_integer64_array(name);
-    } else if (type == typeid(DoubleArray)) {
-        return get_double_array(name);
-    } else {
-        throw std::runtime_error("Unhandled type: " + std::string(type.name()));
+    switch (field_type(name)) {
+        case ValueType::STRING:
+            return get_string(name);
+        case ValueType::DOUBLE:
+            return get_double(name);
+        case ValueType::DOUBLE_ARRAY:
+            return get_double_array(name);
+        case ValueType::INT:
+            return get_int(name);
+        case ValueType::INT64:
+            return get_int64(name);
+        case ValueType::INT_ARRAY:
+            return get_integer_array(name);
+        case ValueType::INT64_ARRAY:
+            return get_integer64_array(name);
     }
+
+    throw std::runtime_error("Unsupported type in Feature::get");
 }
+
 }

--- a/src/feature.h
+++ b/src/feature.h
@@ -16,7 +16,6 @@
 #include <cstdint>
 #include <cstring>
 #include <string>
-#include <typeinfo>
 #include <variant>
 #include <vector>
 
@@ -86,20 +85,93 @@ class Feature
     using DoubleArray = Array<double>;
     using IntegerArray = Array<std::int32_t>;
     using Integer64Array = Array<std::int64_t>;
-    using FieldValue = std::variant<std::string, double, std::int32_t, DoubleArray, IntegerArray, Integer64Array>;
+    using FieldValue = std::variant<std::string, double, std::int32_t, std::int64_t, DoubleArray, IntegerArray, Integer64Array>;
+
+    enum class ValueType
+    {
+        STRING,
+        DOUBLE,
+        DOUBLE_ARRAY,
+        INT,
+        INT64,
+        INT_ARRAY,
+        INT64_ARRAY
+    };
 
     virtual ~Feature()
     {
     }
 
+    struct FieldTypeGetter
+    {
+        constexpr ValueType operator()(double) const
+        {
+            return ValueType::DOUBLE;
+        }
+        constexpr ValueType operator()(std::int32_t) const
+        {
+            return ValueType::INT;
+        }
+        constexpr ValueType operator()(std::size_t) const
+        {
+            return ValueType::INT64;
+        }
+        constexpr ValueType operator()(std::int64_t) const
+        {
+            return ValueType::INT64;
+        }
+        constexpr ValueType operator()(const std::string&) const
+        {
+            return ValueType::STRING;
+        }
+        constexpr ValueType operator()(const DoubleArray&) const
+        {
+            return ValueType::DOUBLE_ARRAY;
+        }
+        constexpr ValueType operator()(const std::vector<double>&) const
+        {
+            return ValueType::DOUBLE_ARRAY;
+        }
+        constexpr ValueType operator()(const std::vector<float>&) const
+        {
+            return ValueType::DOUBLE_ARRAY;
+        }
+        constexpr ValueType operator()(const std::vector<std::int8_t>&) const
+        {
+            return ValueType::INT_ARRAY;
+        }
+        constexpr ValueType operator()(const std::vector<std::int16_t>&) const
+        {
+            return ValueType::INT_ARRAY;
+        }
+        constexpr ValueType operator()(const std::vector<std::int32_t>&) const
+        {
+            return ValueType::INT_ARRAY;
+        }
+        constexpr ValueType operator()(const IntegerArray&) const
+        {
+            return ValueType::INT_ARRAY;
+        }
+        constexpr ValueType operator()(const Integer64Array&) const
+        {
+            return ValueType::INT64_ARRAY;
+        }
+        constexpr ValueType operator()(const std::vector<std::int64_t>&) const
+        {
+            return ValueType::INT64_ARRAY;
+        }
+    };
+
     // Interface methods
-    virtual const std::type_info& field_type(const std::string& name) const = 0;
+    virtual ValueType field_type(const std::string& name) const = 0;
 
     virtual void set(const std::string& name, std::string value) = 0;
 
     virtual void set(const std::string& name, double value) = 0;
 
     virtual void set(const std::string& name, std::int32_t value) = 0;
+
+    virtual void set(const std::string& name, std::int64_t value) = 0;
 
     virtual void set(const std::string& name, const DoubleArray& value) = 0;
 
@@ -114,6 +186,8 @@ class Feature
     virtual DoubleArray get_double_array(const std::string& name) const = 0;
 
     virtual std::int32_t get_int(const std::string& name) const = 0;
+
+    virtual std::int64_t get_int64(const std::string& name) const = 0;
 
     virtual IntegerArray get_integer_array(const std::string& name) const = 0;
 
@@ -141,8 +215,6 @@ class Feature
     virtual void set(const std::string& name, const std::vector<float>& value);
 
     virtual void set(const std::string& name, const std::vector<double>& value);
-
-    virtual void set(const std::string& name, std::int64_t value);
 
     virtual void set(const std::string& name, std::size_t value);
 

--- a/src/gdal_feature.h
+++ b/src/gdal_feature.h
@@ -62,28 +62,28 @@ class GDALFeature : public Feature
     GDALFeature(const GDALFeature& other) = delete;
     GDALFeature& operator=(const GDALFeature& other) = delete;
 
-    const std::type_info& field_type(const std::string& name) const override
+    ValueType field_type(const std::string& name) const override
     {
         auto pos = field_index(name);
         OGRFieldDefnH defn = OGR_F_GetFieldDefnRef(m_feature, pos);
-        auto type = OGR_Fld_GetType(defn);
 
-        if (type == OFTString) {
-            return typeid(std::string);
-        } else if (type == OFTInteger) {
-            return typeid(std::int32_t);
-        } else if (type == OFTInteger64) {
-            return typeid(std::int64_t);
-        } else if (type == OFTReal) {
-            return typeid(double);
-        } else if (type == OFTRealList) {
-            return typeid(DoubleArray);
-        } else if (type == OFTIntegerList) {
-            return typeid(IntegerArray);
-        } else if (type == OFTInteger64List) {
-            return typeid(Integer64Array);
-        } else {
-            throw std::runtime_error("Unhandled type.");
+        switch (OGR_Fld_GetType(defn)) {
+            case OFTString:
+                return ValueType::STRING;
+            case OFTInteger:
+                return ValueType::INT;
+            case OFTIntegerList:
+                return ValueType::INT_ARRAY;
+            case OFTInteger64:
+                return ValueType::INT64;
+            case OFTInteger64List:
+                return ValueType::INT64_ARRAY;
+            case OFTReal:
+                return ValueType::DOUBLE;
+            case OFTRealList:
+                return ValueType::DOUBLE_ARRAY;
+            default:
+                throw std::runtime_error("Unhandled type.");
         }
     }
 

--- a/src/gdal_writer.cpp
+++ b/src/gdal_writer.cpp
@@ -75,23 +75,26 @@ GDALWriter::copy_field(const GDALDatasetWrapper& w, const std::string& name)
 }
 
 OGRFieldType
-GDALWriter::ogr_type(const std::type_info& typ, bool unnest)
+GDALWriter::ogr_type(const Feature::ValueType& typ, bool unnest)
 {
-    if (typ == typeid(std::int8_t) || typ == typeid(std::int16_t) || typ == typeid(std::int32_t) || typ == typeid(std::size_t)) {
-        return OFTInteger;
-    } else if (typ == typeid(double) || typ == typeid(float)) {
-        return OFTReal;
-    } else if (typ == typeid(std::string)) {
-        return OFTString;
-    } else if (typ == typeid(Feature::DoubleArray)) {
-        return unnest ? OFTReal : OFTRealList;
-    } else if (typ == typeid(Feature::IntegerArray)) {
-        return unnest ? OFTInteger : OFTIntegerList;
-    } else if (typ == typeid(Feature::Integer64Array)) {
-        return unnest ? OFTInteger64 : OFTInteger64List;
-    } else {
-        throw std::runtime_error("Unhandled type in GDALWriter::add_operation: " + std::string(typ.name()));
+    switch (typ) {
+        case Feature::ValueType::INT:
+            return OFTInteger;
+        case Feature::ValueType::INT64:
+            return OFTInteger64;
+        case Feature::ValueType::DOUBLE:
+            return OFTReal;
+        case Feature::ValueType::STRING:
+            return OFTString;
+        case Feature::ValueType::DOUBLE_ARRAY:
+            return unnest ? OFTReal : OFTRealList;
+        case Feature::ValueType::INT_ARRAY:
+            return unnest ? OFTInteger : OFTIntegerList;
+        case Feature::ValueType::INT64_ARRAY:
+            return unnest ? OFTInteger64 : OFTInteger64List;
     }
+
+    throw std::runtime_error("Unhandled type in GDALWriter::ogr_type.");
 }
 
 void
@@ -102,7 +105,7 @@ GDALWriter::add_operation(const Operation& op)
 
     const auto& typ = op.result_type();
 
-    if (typ == typeid(Feature::DoubleArray) || typ == typeid(Feature::IntegerArray) || typ == typeid(Feature::Integer64Array)) {
+    if (typ == Feature::ValueType::DOUBLE_ARRAY || typ == Feature::ValueType::INT_ARRAY || typ == Feature::ValueType::INT64_ARRAY) {
         m_contains_nested_fields = true;
     }
 

--- a/src/gdal_writer.h
+++ b/src/gdal_writer.h
@@ -38,7 +38,7 @@ class GDALWriter : public OutputWriter
 
     void copy_field(const GDALDatasetWrapper& w, const std::string& field_name);
 
-    static OGRFieldType ogr_type(const std::type_info&, bool unnest);
+    static OGRFieldType ogr_type(const Feature::ValueType&, bool unnest);
 
   protected:
     GDALDatasetH m_dataset;

--- a/src/map_feature.h
+++ b/src/map_feature.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 ISciences, LLC.
+// Copyright (c) 2023-2024 ISciences, LLC.
 // All rights reserved.
 //
 // This software is licensed under the Apache License, Version 2.0 (the "License").
@@ -42,11 +42,12 @@ class MapFeature : public Feature
 
     MapFeature& operator=(MapFeature&& other) = default;
 
-    const std::type_info& field_type(const std::string& name) const override
+    ValueType field_type(const std::string& name) const override
     {
         const FieldValue& val = m_map.at(name);
-        // https://stackoverflow.com/a/53697591/2171894
-        return std::visit([](auto&& x) -> decltype(auto) { return typeid(x); }, val);
+
+        FieldTypeGetter gft;
+        return std::visit(gft, val);
     }
 
     void set(const std::string& name, double value) override
@@ -77,6 +78,11 @@ class MapFeature : public Feature
     IntegerArray get_integer_array(const std::string& name) const override
     {
         return get<IntegerArray>(name);
+    }
+
+    void set(const std::string& name, std::int64_t value) override
+    {
+        m_map[name] = value;
     }
 
     void set(const std::string& name, const Integer64Array& value) override
@@ -141,6 +147,11 @@ class MapFeature : public Feature
     std::int32_t get_int(const std::string& name) const override
     {
         return get<std::int32_t>(name);
+    }
+
+    std::int64_t get_int64(const std::string& name) const override
+    {
+        return get<std::int64_t>(name);
     }
 
   private:

--- a/src/map_feature.h
+++ b/src/map_feature.h
@@ -42,6 +42,8 @@ class MapFeature : public Feature
 
     MapFeature& operator=(MapFeature&& other) = default;
 
+    using Feature::set;
+
     ValueType field_type(const std::string& name) const override
     {
         const FieldValue& val = m_map.at(name);

--- a/src/operation.h
+++ b/src/operation.h
@@ -106,7 +106,7 @@ class Operation
     Grid<bounded_extent> grid() const;
 
     /// Returns the type of the `Operation` result
-    virtual const std::type_info& result_type() const = 0;
+    virtual Feature::ValueType result_type() const = 0;
 
     /// Returns a key for which a `StatsRegistry` can be queried to get a
     /// `RasterStats` object which can be used to populate the columns associated

--- a/src/raster_source.h
+++ b/src/raster_source.h
@@ -27,10 +27,10 @@ class RasterSource
     virtual const Grid<bounded_extent>& grid() const = 0;
     virtual RasterVariant read_box(const Box& box) = 0;
 
-    const RasterVariant& read_empty()
+    const RasterVariant& read_empty() const
     {
         if (!m_empty) {
-            m_empty = std::make_unique<RasterVariant>(read_box(Box::make_empty()));
+            m_empty = std::make_unique<RasterVariant>(const_cast<RasterSource*>(this)->read_box(Box::make_empty()));
         }
 
         return *m_empty;
@@ -50,7 +50,7 @@ class RasterSource
 
   private:
     std::string m_name;
-    std::unique_ptr<RasterVariant> m_empty;
+    mutable std::unique_ptr<RasterVariant> m_empty;
 };
 }
 

--- a/src/stats_registry.cpp
+++ b/src/stats_registry.cpp
@@ -25,7 +25,7 @@ StatsRegistry::prepare(const Operation& op)
     m_stats_options.store_values |= op.requires_stored_values();
     m_stats_options.store_weights |= op.requires_stored_weights();
     m_stats_options.store_coverage_fraction |= op.requires_stored_coverage_fractions();
-    m_stats_options.store_xy |= op.requries_stored_locations();
+    m_stats_options.store_xy |= op.requires_stored_locations();
     m_stats_options.calc_variance |= op.requires_variance();
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -206,7 +206,7 @@ prepare_operations_implicit(
         RasterSource* v = &*values[i % values.size()];
         RasterSource* w = weights.empty() ? nullptr : &*weights[i % weights.size()];
 
-        ops.push_back(std::make_unique<Operation>(
+        ops.push_back(Operation::create(
           sd.stat,
           make_name(v, w, sd.stat, full_names),
           v,
@@ -255,7 +255,7 @@ prepare_operations_explicit(
         weights = weights_it->second;
     }
 
-    ops.emplace_back(std::make_unique<Operation>(stat.stat, stat.name.empty() ? values->name() + "_" + stat.stat : stat.name, values, weights, stat.args));
+    ops.emplace_back(Operation::create(stat.stat, stat.name.empty() ? values->name() + "_" + stat.stat : stat.name, values, weights, stat.args));
 }
 
 std::vector<std::unique_ptr<Operation>>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 set(TEST_SOURCES
 test_box.cpp
 test_cell.cpp
+test_feature.cpp
 test_geos_utils.cpp
 test_grid.cpp
 test_main.cpp
@@ -22,7 +23,8 @@ test_raster_cell_intersection.cpp
 test_raster_iterator.cpp
 test_traversal_areas.cpp
 test_stats.cpp
-test_utils.cpp)
+test_utils.cpp
+)
 
 # Create an executable to run the unit tests
 add_executable(catch_tests ${TEST_SOURCES})

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -357,7 +357,7 @@ def test_column_naming(
     assert list(rows[0].keys()) == expected_names
 
 
-def test_stats_deferred(run, write_raster, write_features):
+def test_frac_output(run, write_raster, write_features):
     data = np.array([[1, 2, 3], [1, 2, 2], [3, 3, 3]], np.int16)
 
     rows = run(
@@ -372,17 +372,17 @@ def test_stats_deferred(run, write_raster, write_features):
         ),
         fid="id",
         raster=f"class:{write_raster(data)}",
-        stat="frac(class)",
+        stat=["unique", "frac"],
     )
 
-    assert len(rows) == 2
-    assert list(rows[0].keys()) == ["id", "frac_2", "frac_3"]
+    assert len(rows) == 3
 
-    assert rows[0]["frac_2"] == ""
-    assert float(rows[0]["frac_3"]) == 1
+    assert rows[0] == {"id": "1", "unique": "3", "frac": "1"}
 
-    assert float(rows[1]["frac_2"]) == 0.75
-    assert float(rows[1]["frac_3"]) == 0.25
+    # order of rows for a given feature may vary between platforms
+    rows = sorted(rows[1:], key=lambda x: x["unique"])
+    assert rows[0] == {"id": "2", "unique": "2", "frac": "0.75"}
+    assert rows[1] == {"id": "2", "unique": "3", "frac": "0.25"}
 
 
 @pytest.mark.parametrize("strategy", ("feature-sequential", "raster-sequential"))

--- a/test/test_feature.cpp
+++ b/test/test_feature.cpp
@@ -1,0 +1,92 @@
+#include <catch.hpp>
+
+#include "map_feature.h"
+
+using exactextract::MapFeature;
+
+TEMPLATE_TEST_CASE("32-bit int fields", "[feature]", std::int8_t, std::int16_t, std::int32_t)
+{
+    auto x = std::numeric_limits<TestType>::max();
+
+    MapFeature mf;
+    mf.set("name", x);
+
+    CHECK(mf.field_type("name") == MapFeature::ValueType::INT);
+    CHECK(mf.get_int("name") == x);
+}
+
+TEMPLATE_TEST_CASE("64-bit int fields", "[feature]", std::int64_t, std::size_t)
+{
+    auto x = std::numeric_limits<std::int64_t>::max();
+
+    MapFeature mf;
+    mf.set("name", x);
+
+    CHECK(mf.field_type("name") == MapFeature::ValueType::INT64);
+    CHECK(mf.get_int64("name") == x);
+}
+
+TEST_CASE("exception thrown on oversize unsigned int", "[feature]")
+{
+    auto x = static_cast<std::size_t>(std::numeric_limits<std::int64_t>::max()) + 1;
+
+    MapFeature mf;
+    CHECK_THROWS_WITH(mf.set("field", x), Catch::StartsWith("Value is too large"));
+}
+
+TEMPLATE_TEST_CASE("floating point fields", "[feature]", float, double)
+{
+    TestType x = 123.456;
+
+    MapFeature mf;
+    mf.set("name", x);
+
+    CHECK(mf.get_double("name") == x);
+    CHECK(mf.field_type("name") == MapFeature::ValueType::DOUBLE);
+}
+
+TEST_CASE("string fields", "[feature]")
+{
+    MapFeature mf;
+    mf.set("name", "abcdef");
+
+    CHECK(mf.field_type("name") == MapFeature::ValueType::STRING);
+    CHECK(mf.get_string("name") == "abcdef");
+}
+
+TEMPLATE_TEST_CASE("int32 array fields", "[feature]", std::vector<std::int8_t>, std::vector<std::int16_t>, std::vector<std::int32_t>)
+{
+    TestType x{ 4, 5, 7 };
+
+    MapFeature mf;
+    mf.set("name", x);
+
+    CHECK(mf.field_type("name") == MapFeature::ValueType::INT_ARRAY);
+    CHECK(mf.get_integer_array("name").size == 3);
+    CHECK(mf.get_integer_array("name").data[2] == 7);
+}
+
+TEMPLATE_TEST_CASE("int64 array fields", "[feature]", std::vector<std::int64_t>)
+{
+    auto y = std::numeric_limits<std::int64_t>::max() - 2;
+    TestType x{ y, y + 1, y + 2 };
+
+    MapFeature mf;
+    mf.set("name", x);
+
+    CHECK(mf.field_type("name") == MapFeature::ValueType::INT64_ARRAY);
+    CHECK(mf.get_integer64_array("name").size == 3);
+    CHECK(mf.get_integer64_array("name").data[2] == y + 2);
+}
+
+TEMPLATE_TEST_CASE("float array fields", "[feature]", std::vector<float>, std::vector<double>)
+{
+    TestType x{ 4.4, 5.5, 7.7 };
+
+    MapFeature mf;
+    mf.set("name", x);
+
+    CHECK(mf.field_type("name") == MapFeature::ValueType::DOUBLE_ARRAY);
+    CHECK(mf.get_double_array("name").size == 3);
+    CHECK(mf.get_double_array("name").data[2] == static_cast<typename TestType::value_type>(7.7));
+}

--- a/test/test_gdal.cpp
+++ b/test/test_gdal.cpp
@@ -51,7 +51,7 @@ TEST_CASE("GDAL feature access", "[gdal]")
         CHECK(feature.get_int("int_field") == 123);
         feature.set("int_field", 456);
         CHECK(feature.get_int("int_field") == 456);
-        CHECK(feature.field_type("int_field") == typeid(std::int32_t));
+        CHECK(feature.field_type("int_field") == Feature::ValueType::INT);
     }
 
     SECTION("string field access")
@@ -60,16 +60,16 @@ TEST_CASE("GDAL feature access", "[gdal]")
         CHECK(feature.get_string("str_field") == "abc");
         feature.set("str_field", "def");
         CHECK(feature.get_string("str_field") == "def");
-        CHECK(feature.field_type("str_field") == typeid(std::string));
+        CHECK(feature.field_type("str_field") == Feature::ValueType::STRING);
     }
 
     SECTION("int64 field access")
     {
-        feature.set("int64_field", 5000000000);
-        CHECK(feature.get_int64("int64_field") == 5000000000);
-        feature.set("int64_field", 6000000000);
+        feature.set("int64_field", std::int64_t(5000000000));
+        CHECK(feature.get_int64("int64_field") == std::int64_t(5000000000));
+        feature.set("int64_field", std::int64_t(6000000000));
         CHECK(feature.get_int64("int64_field") == 6000000000);
-        CHECK(feature.field_type("int64_field") == typeid(std::int64_t));
+        CHECK(feature.field_type("int64_field") == Feature::ValueType::INT64);
         CHECK_THROWS(feature.set("int64_field", static_cast<std::size_t>(std::numeric_limits<std::int64_t>::max()) + 100));
     }
 
@@ -77,7 +77,7 @@ TEST_CASE("GDAL feature access", "[gdal]")
     {
         feature.set("dbl_field", 123.456);
         CHECK(feature.get_double("dbl_field") == 123.456);
-        CHECK(feature.field_type("dbl_field") == typeid(double));
+        CHECK(feature.field_type("dbl_field") == Feature::ValueType::DOUBLE);
     }
 
     SECTION("int array field access")
@@ -89,7 +89,7 @@ TEST_CASE("GDAL feature access", "[gdal]")
         CHECK(x.data[0] == 1);
         CHECK(x.data[1] == 2);
         CHECK(x.data[2] == 3);
-        CHECK(feature.field_type("int_v_field") == typeid(Feature::IntegerArray));
+        CHECK(feature.field_type("int_v_field") == Feature::ValueType::INT_ARRAY);
 
         std::vector<std::int16_t> int16_v{ 4, 5, 6 };
         feature.set("int_v_field", int16_v);
@@ -98,7 +98,7 @@ TEST_CASE("GDAL feature access", "[gdal]")
         CHECK(x.data[0] == 4);
         CHECK(x.data[1] == 5);
         CHECK(x.data[2] == 6);
-        CHECK(feature.field_type("int_v_field") == typeid(Feature::IntegerArray));
+        CHECK(feature.field_type("int_v_field") == Feature::ValueType::INT_ARRAY);
 
         std::vector<std::int16_t> int8_v{ 7, 8, 9 };
         feature.set("int_v_field", int8_v);
@@ -107,7 +107,7 @@ TEST_CASE("GDAL feature access", "[gdal]")
         CHECK(x.data[0] == 7);
         CHECK(x.data[1] == 8);
         CHECK(x.data[2] == 9);
-        CHECK(feature.field_type("int_v_field") == typeid(Feature::IntegerArray));
+        CHECK(feature.field_type("int_v_field") == Feature::ValueType::INT_ARRAY);
     }
 
     SECTION("int64 array field access")
@@ -118,7 +118,7 @@ TEST_CASE("GDAL feature access", "[gdal]")
         CHECK(x.size == 2);
         CHECK(x.data[0] == 5000000000);
         CHECK(x.data[1] == 6000000000);
-        CHECK(feature.field_type("int64_v_field") == typeid(Feature::Integer64Array));
+        CHECK(feature.field_type("int64_v_field") == Feature::ValueType::INT64_ARRAY);
     }
 
     SECTION("double array field access")
@@ -130,7 +130,7 @@ TEST_CASE("GDAL feature access", "[gdal]")
         CHECK(x.data[0] == 1.1);
         CHECK(x.data[1] == 2.2);
         CHECK(x.data[2] == 3.3);
-        CHECK(feature.field_type("dbl_v_field") == typeid(Feature::DoubleArray));
+        CHECK(feature.field_type("dbl_v_field") == Feature::ValueType::DOUBLE_ARRAY);
     }
 
     CHECK_THROWS(feature.get("does_not_exist"));


### PR DESCRIPTION
The following changes are made to Operation:
- All Operations now assign results to a single column. This affects only the "frac" stat, which now returns an array of fractions instead of magically populating columns like "frac_1", "frac_2", etc. This simplifies the implementation of several classes and removes table-reshaping functionality that is better handled elsewhere.
- All information about a given Operation is now consolidated in its implementation, instead of scattered among string comparisons in multiple "if" blocks.
- The validity of an Operation is now checked when it is instantiated, rather than when results are first written.