### PR TITLE
Fix fiona.open in exact_extract.py

### DIFF
--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -115,7 +115,7 @@ def prep_vec(vec):
         import fiona
 
         if isinstance(vec, (str, os.PathLike)):
-            vec = fiona.Open(vec)
+            vec = fiona.open(vec)
 
         if isinstance(vec, fiona.Collection):
             return JSONFeatureSource(vec)


### PR DESCRIPTION
Update `fiona.Open` to `fiona.open` to fix
```bash
line 118, in prep_vec
    vec = fiona.Open(vec)
AttributeError: module 'fiona' has no attribute 'Open'. Did you mean: 'open'?
```
