### PR TITLE
update_python_docs

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -11,8 +11,7 @@ Python bindings can work with the GDAL Python bindings if they are available.
 
 ## Installation
 
-To install the Python bindings, run `pip install .` from the `python` directory
-of the source tree.
+To install the Python bindings, run `pip install .` from the root of the source tree.
 
 ## Basic usage
 


### PR DESCRIPTION
Running `pip install .` from the python directory will return

```
ERROR: Directory '.' is not installable. Neither 'setup.py' nor 'pyproject.toml' found.
```

Instead, since the pyproject.toml file is in the root of the repository, we should run `pip install .` there which outputs

```
pip install .
Processing ***/exactextract
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: exactextract
  Building wheel for exactextract (pyproject.toml) ... done
  Created wheel for exactextract: filename=exactextract-0.2.0.dev0-cp39-cp39-macosx_14_0_arm64.whl size=277992 sha256=2ca9d9d9a6023c82c0c0125164abdeadf2a0202c0ea1d8c04c6e44c575e994a7
  Stored in directory: /private/var/folders/bg/m4vv93yd2259z40gj5jf8j3r0000gn/T/pip-ephem-wheel-cache-ys5emamv/wheels/08/c6/87/a0e7bec6b34132e5e7bb4d5a8f621b715d4cc2341ed4c397c3
Successfully built exactextract
Installing collected packages: exactextract
  Attempting uninstall: exactextract
    Found existing installation: exactextract 0.2.0.dev0
    Uninstalling exactextract-0.2.0.dev0:
      Successfully uninstalled exactextract-0.2.0.dev0
Successfully installed exactextract-0.2.0.dev0
```

- [x] I ran pre-commit before creating this PR