### PR TITLE
add pybind11 in build requirements

### DIFF
--- a/.github/python_test_env.yml
+++ b/.github/python_test_env.yml
@@ -7,7 +7,6 @@ dependencies:
   - geopandas
   - geos
   - numpy
-  - pybind11
   - pytest
   - pytest-cov
   - rasterio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 dynamic = ["version"]
 
 [build-system]
-requires=["scikit-build-core"]
+requires=["scikit-build-core", "pybind11"]
 build-backend="scikit_build_core.build"
 
 [tool.scikit-build]


### PR DESCRIPTION
`pybind11` is required in order to properly build the project. This PR just add `pybind11` within the pyproject `build-system.requires` in order to avoid any pre-installing step by the user 