### PR TITLE
fix(test_stats): Add include statement and path in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ mkdir cmake-build-release
 cd cmake-build-release
 cmake -DBUILD_CLI:=OFF -DBUILD_DOC:=OFF -DCMAKE_BUILD_TYPE=Release ..
 make
-./catch_tests && sudo make install
+./test/catch_tests && sudo make install
 ```
 
 ### Using `exactextract`

--- a/test/test_stats.cpp
+++ b/test/test_stats.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <sstream>
 #include <valarray>
 
 #include "catch.hpp"


### PR DESCRIPTION
This is a minor fix to `test_stats`. It just adds a missing include statement. I also added a little fix to `README` to run the tests.

**Proposed fix**

Add `#include <sstream>` to `test_stats.cpp`

fixes 115