### PR TITLE
Make it easier to get frac, weighted_frac as a map

### DIFF
--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -218,7 +218,11 @@ def prep_ops(stats, values, weights=None, *, add_unique=False):
             if op.stat == "unique":
                 del need_unique[op.key()]
         for op in need_unique.values():
-            ops += prepare_operations([change_stat(op, "unique")], values, weights)
+            for unique_op in prepare_operations(
+                [change_stat(op, "unique")], values, weights
+            ):
+                unique_op.name = "@delete@" + unique_op.name
+                ops.append(unique_op)
 
     return ops
 

--- a/python/src/exactextract/operation.py
+++ b/python/src/exactextract/operation.py
@@ -4,6 +4,7 @@ from typing import Mapping, Optional
 
 from ._exactextract import Operation as _Operation
 from ._exactextract import PythonOperation  # noqa: F401
+from ._exactextract import change_stat  # noqa: F401
 from ._exactextract import prepare_operations  # noqa: F401
 from .raster import RasterSource
 

--- a/python/src/exactextract/writer.py
+++ b/python/src/exactextract/writer.py
@@ -85,11 +85,15 @@ class JSONWriter(Writer):
 
             key_fields = self._fields_for_stat(key_stat)
             val_fields = self._fields_for_stat(val_stat)
+            if not val_fields:
+                continue
 
             assert len(key_fields) == len(val_fields)
 
             for key_field, val_field in zip(key_fields, val_fields):
                 new_field = val_field.replace(val_stat, field)
+
+                assert len(props[key_field]) == len(props[val_field])
 
                 new_fields[new_field] = {
                     k: v for k, v in zip(props[key_field], props[val_field])

--- a/python/src/pybindings/operation_bindings.cpp
+++ b/python/src/pybindings/operation_bindings.cpp
@@ -123,6 +123,7 @@ bind_operation(py::module& m)
     py::class_<Operation>(m, "Operation")
       .def(py::init(&Operation::create))
       .def("grid", &Operation::grid)
+      .def("key", &Operation::key)
       .def("weighted", &Operation::weighted)
       .def_readonly("stat", &Operation::stat)
       .def_readonly("name", &Operation::name)
@@ -133,5 +134,12 @@ bind_operation(py::module& m)
       .def(py::init<py::function, std::string, RasterSource*, RasterSource*, bool>());
 
     m.def("prepare_operations", py::overload_cast<const std::vector<std::string>&, const std::vector<RasterSource*>&, const std::vector<RasterSource*>&>(&prepare_operations));
+
+    m.def("change_stat", [](const Operation& op, std::string stat) {
+        auto sd = op.descriptor();
+        sd.name = "";
+        sd.stat = stat;
+        return sd.as_string();
+    });
 }
 }

--- a/python/src/pybindings/operation_bindings.cpp
+++ b/python/src/pybindings/operation_bindings.cpp
@@ -126,7 +126,7 @@ bind_operation(py::module& m)
       .def("key", &Operation::key)
       .def("weighted", &Operation::weighted)
       .def_readonly("stat", &Operation::stat)
-      .def_readonly("name", &Operation::name)
+      .def_readwrite("name", &Operation::name)
       .def_readonly("values", &Operation::values)
       .def_readonly("weights", &Operation::weights);
 
@@ -135,7 +135,7 @@ bind_operation(py::module& m)
 
     m.def("prepare_operations", py::overload_cast<const std::vector<std::string>&, const std::vector<RasterSource*>&, const std::vector<RasterSource*>&>(&prepare_operations));
 
-    m.def("change_stat", [](const Operation& op, std::string stat) {
+    m.def("change_stat", [](const Operation& op, std::string_view stat) {
         auto sd = op.descriptor();
         sd.name = "";
         sd.stat = stat;

--- a/python/tests/test_exact_extract.py
+++ b/python/tests/test_exact_extract.py
@@ -1019,14 +1019,15 @@ def test_output_map_fields():
     result = exact_extract(
         rast,
         square,
-        ["frac", "weighted_frac"],
+        ["frac", "weighted_frac", "unique"],
         weights=weights,
-        output_options={"frac_as_map": True},
+        output_options={"frac_as_map": True, "array_type": "set"},
     )
 
     assert result[0]["properties"] == {
         "frac": {1: 0.25, 2: 0.5, 3: 0.1875, 4: 0.0625},
         "weighted_frac": {1: 0.0, 2: 0.0, 3: 0.75, 4: 0.25},
+        "unique": {1, 2, 3, 4},
     }
 
 

--- a/python/tests/test_exact_extract.py
+++ b/python/tests/test_exact_extract.py
@@ -1024,6 +1024,41 @@ def test_output_map_fields():
     }
 
 
+def test_output_map_fields_multiband():
+
+    rast = [
+        NumPyRasterSource(np.arange(1, 10).reshape(3, 3), name="landcov"),
+        NumPyRasterSource(2 * np.arange(1, 10).reshape(3, 3), name="landcat"),
+    ]
+
+    weights = [
+        NumPyRasterSource(np.array([[0, 0, 0], [0, 0, 0], [0.5, 0, 0]]), name="w1"),
+        NumPyRasterSource(np.array([[0, 0, 0], [1, 1, 1], [0, 0, 0]]), name="w2"),
+    ]
+
+    squares = [make_rect(0.5, 0.5, 1.0, 1.0), make_rect(0.5, 0.5, 2.5, 2.5)]
+
+    result = exact_extract(
+        rast,
+        squares,
+        ["unique", "frac", "weighted_frac"],
+        weights=weights,
+        output_options={
+            "map_fields": {
+                "xfrac": ("unique", "frac"),
+                "xweighted_frac": ("unique", "weighted_frac"),
+            }
+        },
+    )
+
+    assert set(result[1]["properties"].keys()) == {
+        "landcat_xfrac",
+        "landcov_xfrac",
+        "landcat_w2_xweighted_frac",
+        "landcov_w1_xweighted_frac",
+    }
+
+
 def test_linear_geom():
 
     rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))

--- a/python/tests/test_exact_extract.py
+++ b/python/tests/test_exact_extract.py
@@ -1008,14 +1008,20 @@ def test_output_map_fields():
     result = exact_extract(
         rast,
         square,
-        ["unique", "frac", "weighted_frac"],
+        "frac(min_coverage_frac=0.5)",
+        output_options={"frac_as_map": True},
+    )
+
+    assert result[0]["properties"] == {
+        "frac": {1: 0.5 / 3, 2: 2 / 3, 3: 0.5 / 3},
+    }
+
+    result = exact_extract(
+        rast,
+        square,
+        ["frac", "weighted_frac"],
         weights=weights,
-        output_options={
-            "map_fields": {
-                "frac": ("unique", "frac"),
-                "weighted_frac": ("unique", "weighted_frac"),
-            }
-        },
+        output_options={"frac_as_map": True},
     )
 
     assert result[0]["properties"] == {
@@ -1041,21 +1047,16 @@ def test_output_map_fields_multiband():
     result = exact_extract(
         rast,
         squares,
-        ["unique", "frac", "weighted_frac"],
+        ["frac", "weighted_frac"],
         weights=weights,
-        output_options={
-            "map_fields": {
-                "xfrac": ("unique", "frac"),
-                "xweighted_frac": ("unique", "weighted_frac"),
-            }
-        },
+        output_options={"frac_as_map": True},
     )
 
     assert set(result[1]["properties"].keys()) == {
-        "landcat_xfrac",
-        "landcov_xfrac",
-        "landcat_w2_xweighted_frac",
-        "landcov_w1_xweighted_frac",
+        "landcat_frac",
+        "landcov_frac",
+        "landcat_w2_weighted_frac",
+        "landcov_w1_weighted_frac",
     }
 
 

--- a/src/operation.cpp
+++ b/src/operation.cpp
@@ -14,7 +14,6 @@
 #include "operation.h"
 #include "utils.h"
 
-#include <charconv>
 #include <sstream>
 
 namespace exactextract {
@@ -384,6 +383,23 @@ class Frac : public OperationImpl<Frac<Weighted>>
     }
 };
 
+StatDescriptor
+Operation::descriptor() const
+{
+    StatDescriptor sd;
+    sd.name = name;
+    sd.stat = stat;
+    sd.values = values->name();
+
+    if (weights) {
+        sd.weights = weights->name();
+    }
+
+    sd.args = m_options;
+
+    return sd;
+}
+
 Operation::
   Operation(std::string p_stat,
             std::string p_name,
@@ -395,6 +411,7 @@ Operation::
   , values{ p_values }
   , weights{ p_weights }
   , m_missing{ get_missing_value() }
+  , m_options{ options }
 {
     m_min_coverage = static_cast<float>(extract_arg<double>(options, "min_coverage_frac", 0));
     if (m_min_coverage == 0) {

--- a/src/operation.h
+++ b/src/operation.h
@@ -156,6 +156,13 @@ class Operation
     /// Populates a field in `f_out` with a missing value
     void set_empty_result(Feature& f_out) const;
 
+    const ArgMap& options() const
+    {
+        return m_options;
+    }
+
+    StatDescriptor descriptor() const;
+
     std::string stat;
     std::string name;
     RasterSource* values;
@@ -183,6 +190,9 @@ class Operation
 
     float m_min_coverage;
     CoverageWeightType m_coverage_weight_type;
+
+  private:
+    const ArgMap m_options;
 };
 
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -171,6 +171,45 @@ parse_stat_descriptor(const std::string& p_descriptor)
     return ret;
 }
 
+std::string
+StatDescriptor::as_string() const
+{
+    std::stringstream desc;
+    if (!name.empty()) {
+        desc << name << "=";
+    }
+    desc << stat;
+
+    if (values.empty() && weights.empty() && args.empty()) {
+        return desc.str();
+    }
+
+    desc << "(";
+
+    bool comma = false;
+
+    if (!values.empty()) {
+        desc << values;
+        comma = true;
+    }
+    if (!weights.empty()) {
+        if (comma) {
+            desc << ",";
+        }
+        desc << weights;
+        comma = true;
+    }
+    for (const auto& [k, v] : args) {
+        if (comma) {
+            desc << ",";
+        }
+        desc << k << "=" << v;
+        comma = true;
+    }
+    desc << ")";
+    return desc.str();
+}
+
 static std::string
 make_name(const RasterSource* v, const RasterSource* w, const std::string& stat, bool full_names)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -36,6 +36,8 @@ struct StatDescriptor
     std::string weights;
     std::string stat;
     std::map<std::string, std::string> args;
+
+    std::string as_string() const;
 };
 
 std::pair<std::string, std::string>

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -124,6 +124,8 @@ TEST_CASE("Parsing stat descriptor with weighting")
     CHECK(descriptor.stat == "mean");
     CHECK(descriptor.values == "deficit");
     CHECK(descriptor.weights == "population");
+
+    CHECK(descriptor.as_string() == "mean(deficit,population)");
 }
 
 TEST_CASE("Parsing stat descriptor with weighting and arguments")
@@ -135,6 +137,8 @@ TEST_CASE("Parsing stat descriptor with weighting and arguments")
     CHECK(descriptor.values == "deficit");
     CHECK(descriptor.weights == "population");
     CHECK(descriptor.args["q"] == "0.75");
+
+    CHECK(descriptor.as_string() == "quantile(deficit,population,q=0.75)");
 }
 
 TEST_CASE("Spaces allowed between arguments")
@@ -146,6 +150,8 @@ TEST_CASE("Spaces allowed between arguments")
     CHECK(descriptor.values == "deficit");
     CHECK(descriptor.weights == "population");
     CHECK(descriptor.args["q"] == "0.75");
+
+    CHECK(descriptor.as_string() == "quantile(deficit,population,q=0.75)");
 }
 
 TEST_CASE("Parsing stat descriptor with name and weighting")
@@ -156,6 +162,8 @@ TEST_CASE("Parsing stat descriptor with name and weighting")
     CHECK(descriptor.stat == "mean");
     CHECK(descriptor.values == "deficit");
     CHECK(descriptor.weights == "population");
+
+    CHECK(descriptor.as_string() == "pop_weighted_mean_deficit=mean(deficit,population)");
 }
 
 TEST_CASE("Parsing stat descriptor with no arguments")
@@ -166,6 +174,8 @@ TEST_CASE("Parsing stat descriptor with no arguments")
     CHECK(descriptor.name == "");
     CHECK(descriptor.values == "");
     CHECK(descriptor.weights == "");
+
+    CHECK(descriptor.as_string() == "mean");
 }
 
 TEST_CASE("Parsing stat descriptor with only keyword arguments")
@@ -177,6 +187,8 @@ TEST_CASE("Parsing stat descriptor with only keyword arguments")
     CHECK(descriptor.values == "");
     CHECK(descriptor.weights == "");
     CHECK(descriptor.args["ignore_nodata"] == "false");
+
+    CHECK(descriptor.as_string() == "mean(ignore_nodata=false)");
 }
 
 TEST_CASE("Parsing stat descriptor with name and no arguments")
@@ -187,6 +199,8 @@ TEST_CASE("Parsing stat descriptor with name and no arguments")
     CHECK(descriptor.name == "pop_mean");
     CHECK(descriptor.values == "");
     CHECK(descriptor.weights == "");
+
+    CHECK(descriptor.as_string() == "pop_mean=mean");
 }
 
 TEST_CASE("Parsing degenerate stat descriptors")


### PR DESCRIPTION
Adds a `frac_as_map` argument that makes the `frac` and `weighted_frac` operations produce a map instead of an array that must be matched with the values of `unique`. Only works in Python and for JSON output.