### PR TITLE
DOC: small improvements to docs

### DIFF
--- a/python/doc/index.rst
+++ b/python/doc/index.rst
@@ -14,7 +14,7 @@ to as `zonal statistics`.
 The goals of ``exactextract`` are to be:
 
 - fast - the :ref:`algorithm <algorithm>` used by ``exactextract`` outperforms many other implementations by avoiding point-in-polygon tests used to determine whether pixels are inside or outside the raster.
-- accurate - ``exactextract`` considers partially-covered pixels by computing the fraction of each pixel that is covered by a polygon and weighting computations using this coverage fraction
+- accurate - ``exactextract`` computes the fraction of each pixel that is covered by a polygon to determine if the pixel should be used and/or to weigh computations using this coverage fraction.
 - scalable - ``exactextract`` avoids the need to load polygon or raster datasets into memory at a single time, allowing it to be used on arbitrarily large datasets with fixed system resources.
 - convenient - ``exactextract`` provides efficient implementations of many common :doc:`summary functions <operations>` and allows the user to define their own functions in R or Python.
 

--- a/python/doc/installation.rst
+++ b/python/doc/installation.rst
@@ -4,6 +4,11 @@ Installation
 The R and Python packages can be installed from `CRAN <https://github.com/isciences/exactextractr>`__ and `PyPI <https://pypi.org/project/exactextract/>`__, respectively.
 If these repositories do not provide a binary for your platform, then you may also need to install the dependencies listed in :ref:`compiling` below.
 
+Another installation option is to use conda. There is both an 
+`R conda package <https://anaconda.org/conda-forge/r-exactextractr>`__ and a
+`python conda package <https://anaconda.org/conda-forge/exactextract>`__ available
+in the `conda-forge` channel.
+
 To use the command line interface, you will likely need to compile it yourself.
 
 .. _compiling:

--- a/python/doc/operations.rst
+++ b/python/doc/operations.rst
@@ -36,6 +36,7 @@ The area covered by the polygon is shaded purple.
            :height: 200
 
 .. list-table::
+    :width: 100%
     :header-rows: 1
 
     * - Name

--- a/python/doc/operations.rst
+++ b/python/doc/operations.rst
@@ -209,6 +209,6 @@ The behavior of these statistics may be modified by the following arguments:
      - `area_cartesian` - :math:`c_i` is the fraction of the pixel multiplied by it x and y resolutions
      - `area_spherical_m2` - :math:`c_i` is the fraction of the pixel that is covered multiplied by a spherical approximation of the cell's area in square meters
      - `area_spherical_km2` - :math:`c_i` is the fraction of the pixel that is covered multiplied by a spherical approximation of the cell's area in square kilometers
-  * ``default_value`` - specifies a value to be used in place of NODATA
-  * ``default_weight`` - specifies a weighing value to be used in place of NODATA
+  * ``default_value`` - specifies a value to be used for NODATA pixels instead of ignoring them
+  * ``default_weight`` - specifies a weighing value to be used for NODATA pixels instead of ignoring them
   * ``min_coverage_frac`` - specifies the minimum fraction of the pixel (0 to 1) that must be covered in order for a pixel to be considered in calculations. Defaults to 0.

--- a/python/doc/operations.rst
+++ b/python/doc/operations.rst
@@ -3,7 +3,7 @@ Available Operations
 
 ``exactextract`` provides numerous built-in operations for summarizing gridded data.
 This page provides a list of the :ref:`operations` and :ref:`arguments tuning their behavior <operation_arguments>`.
-If a built-in operation is not suitable, custom operations can be defined when using eithe the Python or R bindings.
+If a built-in operation is not suitable, custom operations can be defined when using either the Python or R bindings.
 
 .. note::
 

--- a/python/doc/performance.rst
+++ b/python/doc/performance.rst
@@ -20,6 +20,7 @@ With relatively few polygons (hydrologic levels 1-6, up 3500 polygons) processin
 As the number of polygons increases, the resolution of the population raster becomes less significant. 
 At hydrologic levels 9 and 12 (approximately 1 million and 2 million polygons, respectively), increasing the resolution by a factor of 120 increases runtime by only 45%.
 
+.. _performance-processing-strategies:
 
 Processing strategies
 ---------------------

--- a/python/doc/performance.rst
+++ b/python/doc/performance.rst
@@ -29,7 +29,7 @@ Processing strategies
 The "feature sequential" strategy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In the ``feature-sequential`` strategy (the default), ``exactextract`` iterates over the features one at atime, reads the corresponding pixels from each raster, and computes the summary operations.
+In the ``feature-sequential`` strategy (the default), ``exactextract`` iterates over the features one at a time, reads the corresponding pixels from each raster, and computes the summary operations.
 
 This strategy is the most efficient from a memory consumption perspective. The entire vector dataset does not need to be read into memory at once, and statistics for each feature can be flushed to disk before the next feature is read. However, this strategy may be inefficient if the order of features causes the same raster blocks to be read and decompressed multiple times.
 

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -282,7 +282,6 @@ def crs_matches(a, b):
 
 
 def warn_on_crs_mismatch(vec, ops):
-
     check_rast_vec = True
     check_rast_weights = True
 
@@ -321,7 +320,7 @@ def exact_extract(
     output_options: Optional[Mapping] = None,
     progress=False,
 ):
-    """Calculate zonal statistics
+    """Calculate zonal statistics.
 
     Args:
        rast: A :py:class:`RasterSource` or filename that can be opened
@@ -329,7 +328,8 @@ def exact_extract(
        vec: A :py:class:`FeatureSource` or filename that can be opened
              by GDAL/fiona
        ops: A list of :py:class:`Operation` objects, or strings that
-            can be used to construct them (e.g., ``"mean"``, ``"quantile(q=0.33)"``)
+            can be used to construct them (e.g., ``"mean"``, ``"quantile(q=0.33)"``).
+            Check out :doc:`Available operations <operations>` for more information.
        weights: An optional :py:class:`RasterSource` or filename for
             weights to be used in weighted operations.
        include_cols: An optional list of columns from the

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -338,15 +338,17 @@ def exact_extract(
             should be copied from the input features into
             the output.
        strategy: Specifies the strategy to use when processing features.
-                 Must be set to one of:
+          Detailed performance notes are available in
+          :ref:`Performance - Processing strategies <performance-processing-strategies>`.
+          Must be set to one of:
 
                  - ``"feature-sequential"`` (the default):
                    iterate over the features in ``vec``,
                    read the corresponding pixels from ``rast``/``weights``,
                    and compute the summary operations. This offers predictable
                    memory consumption but may be inefficient if the order of
-                   features in ``vec`` causes the same raster blocks to be read
-                   and decompressed.
+                   features in ``vec`` causes the same, relatively large raster
+                   blocks to be read and decompressed many times.
 
                  - ``"raster-sequential"``:
                    iterate over chunks of pixels in ``rast``, identify the intersecting

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -329,7 +329,7 @@ def exact_extract(
              by GDAL/fiona
        ops: A list of :py:class:`Operation` objects, or strings that
             can be used to construct them (e.g., ``"mean"``, ``"quantile(q=0.33)"``).
-            Check out :doc:`Available operations <operations>` for more information.
+            Check out :doc:`Available operations </operations>` for more information.
        weights: An optional :py:class:`RasterSource` or filename for
             weights to be used in weighted operations.
        include_cols: An optional list of columns from the


### PR DESCRIPTION
- In python api docs of `exact_extract`:
    - Add link to "Available operations" to description of parameter `ops`.
    - Add link to the relevant section in the "Performance" to the description of parameter `strategy`.
- Clarify descriptions of operation arguments `default_value` and `default_weight`: reference https://github.com/isciences/exactextract/issues/147#issuecomment-2310699532
- In "index" page: change to exactextract being "accurate" description so it is applicable to more use cases.
- In "Installation" page, add conda as installation option.
- Set width : 100% on the table with all operations to rather have the description become multi-line on smaller screens than horizontal scrolbars appearing