### PR TITLE
MAINT: use ruff instead of black, flake, isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,12 @@
 repos:
-    -   repo: https://github.com/psf/black
-        rev: 22.3.0
-        hooks:
-        -   id: black
-    -   repo: https://github.com/timothycrosley/isort
-        rev: 5.12.0
-        hooks:
-        -   id: isort
-    -   repo: https://github.com/pycqa/flake8
-        rev: 3.9.2
-        hooks:
-        -   id: flake8
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: "v0.6.3"
+      hooks:
+          # Format the code
+          - id: ruff-format
+          # Lint the code
+          - id: ruff
+            # args: [ --fix ]
     -   repo: https://github.com/pre-commit/mirrors-clang-format
         rev: 'v15.0.7'
         hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 name = "exactextract"
 description = "Fast and accurate raster zonal statistics"
 license.file = "LICENSE"
-url = "https://github.com/isciences/exactextract"
 authors = [
   { "name" = "Daniel Baston" }
 ]
@@ -20,6 +19,9 @@ classifiers = [
 ]
 dynamic = ["version"]
 readme = "README.md"
+
+[project.urls]
+repository = "https://github.com/isciences/exactextract"
 
 [build-system]
 requires=["scikit-build-core", "pybind11"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,88 @@ wheel.packages=["python/src/exactextract"]
 provider = "scikit_build_core.metadata.regex"
 input = "cmake/VersionSource.cmake"
 regex = "EXACTEXTRACT_VERSION_SOURCE \"(?P<value>.+)\""
+
+[tool.ruff]
+line-length = 88
+extend-exclude = ["*.ipynb", "local_ignore/*"]
+
+[tool.ruff.lint]
+select = [
+    # pyflakes
+    "F",
+    # pycodestyle
+    "E",
+    "W",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-debugger
+    "T10",
+    # flake8-simplify
+    # "SIM",
+    # pylint
+    "PLC",
+    "PLE",
+    "PLR",
+    "PLW",
+    # misc lints
+    "PIE",
+    # implicit string concatenation
+    "ISC",
+    # type-checking imports
+    "TCH",
+    # comprehensions
+    "C4",
+    # Ruff-specific rules
+    "RUF",
+    # isort
+    "I",
+    # pydocstyle
+    #"D",
+]
+
+ignore = [
+    ### Intentionally disabled
+    # module level import not at top of file
+    "E402",
+    # do not assign a lambda expression, use a def
+    "E731",
+    # mutable-argument-default
+    "B006",
+    # unused-loop-control-variable
+    "B007",
+    # get-attr-with-constant
+    "B009",
+    # Only works with python >=3.10
+    "B905",
+    # dict literals
+    "C408",
+    # Too many arguments to function call
+    "PLR0913",
+    # Too many returns
+    "PLR0911",
+    # Too many branches
+    "PLR0912",
+    # Too many statements
+    "PLR0915",
+    # Magic number
+    "PLR2004",
+    # Consider `elif` instead of `else` then `if` to remove indentation level
+    "PLR5501",
+    # Redefined loop name
+    "PLW2901",
+    # Global statements are discouraged
+    "PLW0603",
+    # compare-to-empty-string
+    "PLC1901",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["D"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.pyupgrade]
+keep-runtime-typing = true

--- a/python/doc/conf.py
+++ b/python/doc/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
 #
@@ -74,7 +73,6 @@ autoapi_options = ["members", "undoc-members", "show-module-summary", "special-m
 
 
 def autoapi_skip_member(app, what, name, obj, skip, options):
-
     shortname = name.split(".")[-1]
 
     # Don't emit documentation for anything named beginning with

--- a/python/src/exactextract/__init__.py
+++ b/python/src/exactextract/__init__.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
-""" Python bindings for exactextract """
+"""Python bindings for exactextract."""
+# ruff: noqa: F401
 
 from ._exactextract import __version__
 from .exact_extract import exact_extract

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -2,8 +2,9 @@ import copy
 import functools
 import os
 import warnings
+from collections.abc import Mapping
 from itertools import chain
-from typing import Mapping, Optional
+from typing import Optional
 
 from .feature import (
     FeatureSource,
@@ -40,7 +41,8 @@ def make_raster_names(root: str, nbands: int) -> list:
 
 def prep_raster_gdal(rast, name_root=None) -> list:
     try:
-        # eagerly import gdal_array to avoid possible ImportError when reading raster data
+        # eagerly import gdal_array to avoid possible ImportError when reading raster
+        # data
         from osgeo import gdal, gdal_array  # noqa: F401
 
         if isinstance(rast, (str, os.PathLike)):
@@ -93,7 +95,6 @@ def prep_raster_rasterio(rast, name_root=None) -> list:
 
 
 def prep_raster_xarray(rast, name_root=None) -> list:
-
     try:
         import rioxarray  # noqa: F401
         import xarray
@@ -240,7 +241,7 @@ def prep_ops(stats, values, weights=None, *, add_unique=False):
                 if "No weights provided" in str(e):
                     raise Exception(
                         f"No weights provided but {stat.__name__} expects 3 arguments"
-                    )
+                    ) from None
                 else:
                     raise
         elif isinstance(stat, Operation):
@@ -328,8 +329,10 @@ def warn_on_crs_mismatch(vec, ops):
         if check_rast_vec and not crs_matches(vec, op.values):
             check_rast_vec = False
             warnings.warn(
-                "Spatial reference system of input features does not exactly match raster.",
+                "Spatial reference system of input features does not exactly match "
+                "raster.",
                 RuntimeWarning,
+                stacklevel=2,
             )
 
         if (
@@ -339,8 +342,10 @@ def warn_on_crs_mismatch(vec, ops):
         ):
             check_rast_weights = False
             warnings.warn(
-                "Spatial reference system of input features does not exactly match weighting raster.",
+                "Spatial reference system of input features does not exactly match "
+                "weighting raster.",
                 RuntimeWarning,
+                stacklevel=2,
             )
 
 
@@ -396,22 +401,25 @@ def exact_extract(
                    a cost of higher memory usage.
        max_cells_in_memory: Indicates the maximum number of raster cells that should be
                             loaded into memory at a given time.
-       grid_compat_tol: require value and weight grids to align within ``grid_compat_tol`` times the smaller of the two grid resolutions
+       grid_compat_tol: require value and weight grids to align within
+            ``grid_compat_tol`` times the smaller of the two grid resolutions
        output: An :py:class:`OutputWriter` or one of the following strings:
 
-                 - "geojson" (the default): return a list of GeoJSON-like features
-                 - "pandas": return a ``pandas.DataFrame`` or ``geopandas.GeoDataFrame``,
-                             depending on the value of ``include_geom``
-                 - "gdal": write results to disk using GDAL/OGR as they are written. This
-                           option (with ``strategy="feature-sequential"``) avoids the need
-                           to maintain results for all features in memory at a single time,
-                           which may be significant for operations with large result sizes
-                           such as ``cell_id``, ``values``, etc.
-       output_options: an optional dictionary of options passed to the :py:class:`writer.JSONWriter`, :py:class:`writer.PandasWriter`, or :py:class:`writer.GDALWriter`.
-       progress: if `True`, a progress bar will be displayed. Alternatively, a
-                 function may be provided that will be called with the completion fraction
-                 and a status message.
-    """
+                - "geojson" (the default): return a list of GeoJSON-like features
+                - "pandas": return a ``pandas.DataFrame`` or ``geopandas.GeoDataFrame``,
+                            depending on the value of ``include_geom``
+                - "gdal": write results to disk using GDAL/OGR as they are written. This
+                          option (with ``strategy="feature-sequential"``) avoids the
+                          need to maintain results for all features in memory at a
+                          single time, which may be significant for operations with
+                          large result sizes such as ``cell_id``, ``values``, etc.
+       output_options: an optional dictionary of options passed to the
+            :py:class:`writer.JSONWriter`, :py:class:`writer.PandasWriter`, or
+            :py:class:`writer.GDALWriter`.
+       progress: if `True`, a progress bar will be displayed. Alternatively, a function
+            may be provided that will be called with the completion fraction and a
+            status message.
+    """  # noqa: E501
     rast = prep_raster(rast)
     weights = prep_raster(weights, name_root="weight")
     vec = prep_vec(vec)

--- a/python/src/exactextract/feature.py
+++ b/python/src/exactextract/feature.py
@@ -13,8 +13,7 @@ __all__ = [
 
 
 class FeatureSource(_FeatureSource):
-    """
-    Source from which polygon features can be read.
+    """Source from which polygon features can be read.
 
     Several implementations are included in exactextract:
 
@@ -25,24 +24,26 @@ class FeatureSource(_FeatureSource):
     """
 
     def __init__(self):
+        """Constructor."""
         super().__init__()
 
 
 class GDALFeatureSource(FeatureSource):
-    """
-    A FeatureSource using the GDAL/OGR Python interface to provide features.
-    """
+    """A FeatureSource using the GDAL/OGR Python interface to provide features."""
 
     def __init__(self, src):
-        """
+        """Constructor.
+
         Args:
-            src: one of the following
-                 - string or Path to a file/datasource that can be opened with GDAL/OGR
-                 - a ``gdal.Dataset``
-                 - an ``ogr.DataSource``
-                 - an ``ogr.Layer``
-                 If the file has more than one layer, e.g., a GeoPackage, an
-                 ``ogr.Layer`` must be provided directly.
+            src: one of the following:
+
+                - string or Path to a file/datasource that can be opened with GDAL/OGR
+                - a ``gdal.Dataset``
+                - an ``ogr.DataSource``
+                - an ``ogr.Layer``
+                If the file has more than one layer, e.g., a GeoPackage, an
+                ``ogr.Layer`` must be provided directly.
+
         """
         super().__init__()
 
@@ -59,7 +60,8 @@ class GDALFeatureSource(FeatureSource):
             self.ds = src  # keep a reference to ds
             if nlayers > 1:
                 raise Exception(
-                    "Can only process a single layer; call directly with ogr.Layer object."
+                    "Can only process a single layer; call directly with ogr.Layer "
+                    "object."
                 )
 
             self.src = src.GetLayer(0)
@@ -124,9 +126,7 @@ class GDALFeature(Feature):
 
 
 class JSONFeatureSource(FeatureSource):
-    """
-    A FeatureSource providing GeoJSON-like features.
-    """
+    """A FeatureSource providing GeoJSON-like features."""
 
     def __init__(self, src, *, srs_wkt=None):
         super().__init__()
@@ -197,9 +197,7 @@ class JSONFeature(Feature):
 
 
 class GeoPandasFeatureSource(FeatureSource):
-    """
-    A FeatureSource using GeoPandas GeoDataFrame to provide features.
-    """
+    """A FeatureSource using GeoPandas GeoDataFrame to provide features."""
 
     def __init__(self, src):
         super().__init__()

--- a/python/src/exactextract/operation.py
+++ b/python/src/exactextract/operation.py
@@ -1,19 +1,26 @@
+"""Operations for summarizing raster values."""
+
 from __future__ import annotations
 
-from typing import Callable, Mapping, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 from ._exactextract import Operation as _Operation
 from ._exactextract import PythonOperation as _PythonOperation
-from ._exactextract import change_stat  # noqa: F401
-from ._exactextract import prepare_operations  # noqa: F401
-from .raster import RasterSource
+from ._exactextract import (
+    change_stat,  # noqa: F401
+    prepare_operations,  # noqa: F401
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from .raster import RasterSource
 
 __all__ = ["Operation", "PythonOperation"]
 
 
 class Operation(_Operation):
-    """
-    Summarize of pixel values using a built-in function
+    """Summarize of pixel values using a built-in function.
 
     Defines a summary operation to be performed on pixel values intersecting
     a geometry. May return a scalar (e.g., ``weighted_mean``), or a
@@ -28,14 +35,15 @@ class Operation(_Operation):
         weights: Optional[RasterSource] = None,
         options: Optional[Mapping] = None,
     ):
-        """
+        """Constructor for Operation.
+
         Args:
             stat_name: Name of the stat. Refer to docs for options.
             field_name: Name of the result field that is assigned by this Operation.
             raster: Raster to compute over.
             weights: Weight raster to use. Defaults to None.
-            options: Arguments used to control the behavior of an Operation, e.g. ``options={"q": 0.667}``
-                     with ``stat_name = "quantile"``
+            options: Arguments used to control the behavior of an Operation, e.g.
+                ``options={"q": 0.667}`` with ``stat_name = "quantile"``
         """
         if raster is None:
             raise TypeError
@@ -49,8 +57,7 @@ class Operation(_Operation):
 
 
 class PythonOperation(_PythonOperation):
-    """
-    Summarize of pixel values using a Python function
+    """Summarize of pixel values using a Python function
 
     Defines a summary operation to be performed on pixel values intersecting
     a geometry.
@@ -63,19 +70,17 @@ class PythonOperation(_PythonOperation):
         raster: RasterSource,
         weights: Optional[RasterSource],
     ):
+        """Args:
+        function: Function accepting either two arguments (if `weights` is `None`),
+                  or three arguments. The function will be called with
+                  arrays of equal length containing:
+                  - pixel values from `raster` (masked array)
+                  - cell coverage fractions
+                  - pixel values from `weights` (masked array)
+        field_name: Name of the result field that is assigned by this Operation.
+        raster: Raster to compute over.
+        weights: Weight raster to use. Defaults to None.
         """
-        Args:
-            function: Function accepting either two arguments (if `weights` is `None`),
-                      or three arguments. The function will be called with
-                      arrays of equal length containing:
-                      - pixel values from `raster` (masked array)
-                      - cell coverage fractions
-                      - pixel values from `weights` (masked array)
-            field_name: Name of the result field that is assigned by this Operation.
-            raster: Raster to compute over.
-            weights: Weight raster to use. Defaults to None.
-        """
-
         if raster is None:
             raise TypeError
 

--- a/python/src/exactextract/processor.py
+++ b/python/src/exactextract/processor.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from ._exactextract import FeatureSequentialProcessor as _FeatureSequentialProcessor
 from ._exactextract import Processor  # noqa: F401
@@ -17,16 +17,15 @@ class FeatureSequentialProcessor(_FeatureSequentialProcessor):
         self,
         ds: FeatureSource,
         writer: Writer,
-        op_list: List[Operation],
-        include_cols: Optional[List[Operation]] = None,
+        op_list: list[Operation],
+        include_cols: Optional[list[Operation]] = None,
     ):
-        """
-        Args:
-            ds (FeatureSource): Dataset to use
-            writer (Writer): Writer to use
-            op_list: List of Operations to perform
-            include_cols: List of columns to copy from
-               input features
+        """Args:
+        ds (FeatureSource): Dataset to use
+        writer (Writer): Writer to use
+        op_list: List of Operations to perform
+        include_cols: List of columns to copy from
+           input features
         """
         super().__init__(ds, writer)
         for col in include_cols or []:
@@ -36,22 +35,21 @@ class FeatureSequentialProcessor(_FeatureSequentialProcessor):
 
 
 class RasterSequentialProcessor(_RasterSequentialProcessor):
-    """Binding class around exactextract RasterSequentialProcessor"""
+    """Binding class around exactextract RasterSequentialProcessor."""
 
     def __init__(
         self,
         ds: FeatureSource,
         writer: Writer,
-        op_list: List[Operation],
-        include_cols: Optional[List[Operation]] = None,
+        op_list: list[Operation],
+        include_cols: Optional[list[Operation]] = None,
     ):
-        """
-        Args:
-            ds (FeatureSource): Dataset to use
-            writer (Writer): Writer to use
-            op_list (List[Operation]): List of operations
-            include_cols: List of columns to copy from
-               input features
+        """Args:
+        ds (FeatureSource): Dataset to use
+        writer (Writer): Writer to use
+        op_list (List[Operation]): List of operations
+        include_cols: List of columns to copy from
+           input features
         """
         super().__init__(ds, writer)
         for col in include_cols or []:

--- a/python/src/exactextract/raster.py
+++ b/python/src/exactextract/raster.py
@@ -6,8 +6,7 @@ from ._exactextract import RasterSource as _RasterSource
 
 
 class RasterSource(_RasterSource):
-    """
-    Source from which raster data can be read.
+    """Source from which raster data can be read.
 
     A RasterSource provides the ability to read subsets of a single band of
     raster data. Several implementations are included in exactextract:
@@ -23,17 +22,13 @@ class RasterSource(_RasterSource):
 
 
 class GDALRasterSource(RasterSource):
-    """
-    RasterSource backed by GDAL
-    """
+    """RasterSource backed by GDAL"""
 
     def __init__(self, ds, band_idx: int = 1, *, name=None):
-        """
-
-        Args:
-            ds: A ``gdal.Dataset`` or path from which one can be opened
-            band_idx: 1-based numerical index of band to read
-            name: source name, to be used in generating field names for results
+        """Args:
+        ds: A ``gdal.Dataset`` or path from which one can be opened
+        band_idx: 1-based numerical index of band to read
+        name: source name, to be used in generating field names for results
         """
         super().__init__()
         from osgeo import gdal
@@ -80,7 +75,8 @@ class GDALRasterSource(RasterSource):
 
     def nodata_value(self):
         if self.scaled:
-            # for scaled rasters we rely on the NODATA mask rather than inverting the scaling
+            # for scaled rasters we rely on the NODATA mask rather than inverting the
+            # scaling
             return None
 
         val = self.band.GetNoDataValue()
@@ -100,7 +96,6 @@ class GDALRasterSource(RasterSource):
         return True
 
     def read_window(self, x0, y0, nx, ny):
-
         arr = self.band.ReadAsArray(xoff=x0, yoff=y0, win_xsize=nx, win_ysize=ny)
 
         mask = None
@@ -133,9 +128,7 @@ class GDALRasterSource(RasterSource):
 
 
 class NumPyRasterSource(RasterSource):
-    """
-    RasterSource backed by a NumPy array
-    """
+    """RasterSource backed by a NumPy array"""
 
     def __init__(
         self,
@@ -147,10 +140,9 @@ class NumPyRasterSource(RasterSource):
         *,
         nodata=None,
         name=None,
-        srs_wkt=None
+        srs_wkt=None,
     ):
-        """
-        Create a RasterSource that references a NumPy array.
+        """Create a RasterSource that references a NumPy array.
 
         If spatial extent arguments are not provided, the extent will be assumed to be
         from (0,0) to (nx,ny).
@@ -201,17 +193,13 @@ class NumPyRasterSource(RasterSource):
 
 
 class RasterioRasterSource(RasterSource):
-    """
-    RasterSource backed by rasterio
-    """
+    """RasterSource backed by rasterio"""
 
     def __init__(self, ds, band_idx=1, *, name=None):
-        """
-
-        Args:
-            ds: A ``rasterio.DatasetReader`` or path from which one can be opened
-            band_idx: 1-based numerical index of band to read
-            name: source name, to be used in generating field names for results
+        """Args:
+        ds: A ``rasterio.DatasetReader`` or path from which one can be opened
+        band_idx: 1-based numerical index of band to read
+        name: source name, to be used in generating field names for results
         """
         super().__init__()
         if isinstance(ds, (str, os.PathLike)):
@@ -275,20 +263,17 @@ class RasterioRasterSource(RasterSource):
 
 
 class XArrayRasterSource(RasterSource):
-    """
-    RasterSource backed by xarray
+    """RasterSource backed by xarray
 
     The rio-xarray extension is used to retrieve metadata such as the
     array extent, resolution, and spatial reference system.
     """
 
     def __init__(self, ds, band_idx=1, *, name=None):
-        """
-
-        Args:
-            ds: An xarray ``DataArray`` or a path from which one can be read.
-            band_idx: 1-based numerical index of band to read
-            name: source name, to be used in generating field names for results
+        """Args:
+        ds: An xarray ``DataArray`` or a path from which one can be read.
+        band_idx: 1-based numerical index of band to read
+        name: source name, to be used in generating field names for results
         """
         super().__init__()
 

--- a/python/src/exactextract/writer.py
+++ b/python/src/exactextract/writer.py
@@ -1,6 +1,7 @@
 import copy
 import os
-from typing import Mapping, Optional, Tuple
+from collections.abc import Mapping
+from typing import Optional
 
 from ._exactextract import Writer as _Writer
 from .feature import GDALFeature, JSONFeature, QGISFeature
@@ -16,25 +17,22 @@ class Writer(_Writer):
 
 
 class JSONWriter(Writer):
-    """
-    Creates GeoJSON-like features
-    """
+    """Creates GeoJSON-like features"""
 
     def __init__(
         self,
         *,
         array_type: str = "numpy",
-        map_fields: Optional[Mapping[str, Tuple[str]]] = None
+        map_fields: Optional[Mapping[str, tuple[str]]] = None,
     ):
-        """
-        Args:
-            array_type: type that should be used to represent array outputs.
-                        either "numpy" (default), "list", or "set"
-            map_fields: an optional dictionary of fields to be created by
-                        interpreting one field as keys and another as values, in the format
-                        ``{ dst_field : (src_keys, src_vals) }``. for example, the fields
-                        "values" and "frac" would be combined into a field called
-                        "frac_map" using ``map_fields = {"frac_map": ("values", "frac")}``.
+        """Args:
+        array_type: type that should be used to represent array outputs.
+                    either "numpy" (default), "list", or "set"
+        map_fields: an optional dictionary of fields to be created by
+                    interpreting one field as keys and another as values, in the format
+                    ``{ dst_field : (src_keys, src_vals) }``. for example, the fields
+                    "values" and "frac" would be combined into a field called
+                    "frac_map" using ``map_fields = {"frac_map": ("values", "frac")}``.
         """
         super().__init__()
 
@@ -106,9 +104,7 @@ class JSONWriter(Writer):
 
                 assert len(props[key_field]) == len(props[val_field])
 
-                new_fields[new_field] = {
-                    k: v for k, v in zip(props[key_field], props[val_field])
-                }
+                new_fields[new_field] = dict(zip(props[key_field], props[val_field]))
 
         props.update(new_fields)
 
@@ -210,12 +206,12 @@ class QGISWriter(Writer):
         return self.vector_layer
 
     def _create_vector_layer(self):
-        """
-        Creates a vector layer with the defined geometry type, CRS and fields.
+        """Creates a vector layer with the defined geometry type, CRS and fields.
         Returns the created layer as well as its data provider.
 
         Returns:
-            Tuple[QgsVectorLayer, QgsVectorDataProvider]: initialized vector layer, data provider for created vector layer
+            Tuple[QgsVectorLayer, QgsVectorDataProvider]: initialized vector layer, data
+                provider for created vector layer
         """
         from qgis.core import QgsVectorLayer
 
@@ -228,14 +224,14 @@ class QGISWriter(Writer):
 
         # add fields
         data_provider.addAttributes(self.fields)
-        vector_layer.updateFields()  # tell the vector layer to fetch changes from the provider
+        # tell the vector layer to fetch changes from the provider
+        vector_layer.updateFields()
 
         return vector_layer, data_provider
 
     @staticmethod
     def _get_geometry_type(feature: JSONFeature) -> str:
-        """
-        get geometry type of an input feature geometry
+        """Get geometry type of an input feature geometry
 
         Args:
             feature (JSONFeature): feature with geometry field
@@ -253,8 +249,7 @@ class QGISWriter(Writer):
 
     @staticmethod
     def _convert_to_QgsFields(fields_list: list):
-        """
-        Converts a list with `QgsField` into a `QgsFields` object
+        """Converts a list with `QgsField` into a `QgsFields` object
 
         Args:
             fields_list (list): list with `QgsField`
@@ -272,9 +267,10 @@ class QGISWriter(Writer):
 
     @staticmethod
     def _set_fields_types(fields_list: list[str], feature: JSONFeature) -> list:
-        """
-        Sets field types based on provided data. If no type is specified it will be set as string by default
-        with type_name set as "Unknown".
+        """Sets field types based on provided data.
+
+        If no type is specified it will be set as string by default with type_name set
+        as "Unknown".
 
         Args:
             fields_list (list[str]): list with fields names
@@ -321,15 +317,14 @@ class GDALWriter(Writer):
     def __init__(
         self, dataset=None, *, filename=None, driver=None, layer_name="", srs_wkt=None
     ):
-        """
-        Args:
-            dataset: a ``gdal.Dataset`` or ``ogr.DataSource`` to which results
-                     should be created in a new layer
-            filename: file to write results to, if ``dataset`` is ``None``
-            driver: driver to use when creating ``filename``
-            layer_name: name of new layer to create in output dataset
-            srs_wkt: spatial reference system to assign to output dataset. No
-                     coordinate transformation will be performed.
+        """Args:
+        dataset: a ``gdal.Dataset`` or ``ogr.DataSource`` to which results
+                 should be created in a new layer
+        filename: file to write results to, if ``dataset`` is ``None``
+        driver: driver to use when creating ``filename``
+        layer_name: name of new layer to create in output dataset
+        srs_wkt: spatial reference system to assign to output dataset. No
+                 coordinate transformation will be performed.
         """
         super().__init__()
 
@@ -341,7 +336,6 @@ class GDALWriter(Writer):
             )
             self.ds = dataset
         elif isinstance(filename, (str, os.PathLike)):
-
             from osgeo_utils.auxiliary.util import GetOutputDriverFor
 
             if driver is None:

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,2 +1,1 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from exactextract.raster import NumPyRasterSource
 
 

--- a/python/tests/test_exact_extract.py
+++ b/python/tests/test_exact_extract.py
@@ -5,7 +5,6 @@ import warnings
 
 import numpy as np
 import pytest
-
 from exactextract import Operation, exact_extract
 from exactextract.feature import JSONFeatureSource
 from exactextract.raster import NumPyRasterSource
@@ -20,7 +19,7 @@ def output_format(request):
 
 
 def prop_map(f, k, v):
-    return {v: f for v, f in zip(f["properties"][k], f["properties"][v])}
+    return dict(zip(f["properties"][k], f["properties"][v]))
 
 
 def make_square_raster(n):
@@ -552,7 +551,6 @@ def test_all_nodata_pandas():
 
 
 def test_all_nodata_qgis():
-
     pytest.importorskip("qgis.core")
 
     data = np.full((3, 3), -999, dtype=np.int32)
@@ -571,7 +569,6 @@ def test_all_nodata_qgis():
 
 
 def test_all_nodata_gdal():
-
     ogr = pytest.importorskip("osgeo.ogr")
 
     data = np.array([[1, 1, 1], [-999, -999, -999], [-999, -999, -999]], dtype=np.int32)
@@ -589,7 +586,7 @@ def test_all_nodata_gdal():
         output_options={"dataset": ds},
     )
 
-    features = [f for f in ds.GetLayer(0)]
+    features = list(ds.GetLayer(0))
 
     assert math.isnan(features[1]["mean"])
     assert features[1]["variety"] == 0
@@ -884,7 +881,8 @@ def test_gdal_data_types(tmp_path, rast_lib, dtype):
         assert type(results["mode"]) is int
 
 
-# Check that a negative nodata value for a raster with type GDT_Byte is ignored rather than causing an exception
+# Check that a negative nodata value for a raster with type GDT_Byte is ignored rather
+# than causing an exception
 def test_gdal_invalid_nodata_value(tmp_path):
     gdal = pytest.importorskip("osgeo.gdal")
 
@@ -991,7 +989,6 @@ def test_error_rotated_inputs(tmp_path, rast_lib):
 
 @pytest.mark.parametrize("dtype", (np.float64, np.float32, np.int32, np.int64))
 def test_types_preserved(dtype):
-
     rast = NumPyRasterSource(np.full((3, 3), 1, dtype))
 
     square = make_rect(0, 0, 3, 3)
@@ -1129,7 +1126,7 @@ def test_qgis_output():
         include_geom=True,
     )
 
-    features = [f for f in result.getFeatures()]
+    features = list(result.getFeatures())
 
     assert len(features) == 1
 
@@ -1163,7 +1160,6 @@ def test_masked_array():
 
 
 def test_output_no_numpy():
-
     rast = NumPyRasterSource(np.arange(1, 10, dtype=np.int32).reshape(3, 3))
     square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5))
 
@@ -1175,7 +1171,6 @@ def test_output_no_numpy():
 
 
 def test_output_map_fields():
-
     rast = NumPyRasterSource(np.array([[1, 1, 1], [2, 2, 2], [3, 3, 4]]))
     weights = NumPyRasterSource(np.array([[0, 0, 0], [0, 0, 0], [1, 1, 1]]))
     square = make_rect(0.5, 0.5, 2.5, 2.5)
@@ -1207,7 +1202,6 @@ def test_output_map_fields():
 
 
 def test_output_map_fields_multiband():
-
     rast = [
         NumPyRasterSource(np.arange(1, 10).reshape(3, 3), name="landcov"),
         NumPyRasterSource(2 * np.arange(1, 10).reshape(3, 3), name="landcat"),
@@ -1237,7 +1231,6 @@ def test_output_map_fields_multiband():
 
 
 def test_linear_geom():
-
     rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))
     line = {
         "type": "Feature",
@@ -1262,7 +1255,6 @@ def test_linear_geom():
 
 
 def test_point_geom():
-
     rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))
 
     point = {
@@ -1275,7 +1267,6 @@ def test_point_geom():
 
 
 def test_custom_function_throws_exception():
-
     rast = NumPyRasterSource(np.arange(9).reshape(3, 3))
     square = make_rect(0.5, 0.5, 2.5, 2.5)
 
@@ -1287,7 +1278,6 @@ def test_custom_function_throws_exception():
 
 
 def test_custom_function_missing_weights():
-
     rast = NumPyRasterSource(np.arange(9).reshape(3, 3))
     square = make_rect(0.5, 0.5, 2.5, 2.5)
 
@@ -1299,7 +1289,6 @@ def test_custom_function_missing_weights():
 
 
 def test_custom_function_bad_signature():
-
     rast = NumPyRasterSource(np.arange(9).reshape(3, 3))
     square = make_rect(0.5, 0.5, 2.5, 2.5)
 
@@ -1323,7 +1312,6 @@ def test_custom_function_bad_signature():
 
 
 def test_custom_function_bad_return_type():
-
     rast = NumPyRasterSource(np.arange(9).reshape(3, 3))
     square = make_rect(0.5, 0.5, 2.5, 2.5)
 
@@ -1344,7 +1332,6 @@ def test_custom_function_bad_return_type():
     ids=lambda x: f"ndarray[{x.dtype}]" if hasattr(x, "dtype") else type(x),
 )
 def test_custom_function_return_types(ret):
-
     rast = NumPyRasterSource(np.arange(9).reshape(3, 3))
     square = make_rect(0.5, 0.5, 2.5, 2.5)
 
@@ -1362,7 +1349,6 @@ def test_custom_function_return_types(ret):
 
 
 def test_custom_function():
-
     rast = NumPyRasterSource(np.arange(9).reshape(3, 3))
     weights = NumPyRasterSource(np.sqrt(np.arange(9).reshape(3, 3)))
     square = make_rect(0.5, 0.5, 2.5, 2.5)
@@ -1418,8 +1404,9 @@ def test_custom_function_nodata(weighted):
             weights=rast_weights,
         )
 
-        # Unlike values, weights are always coerced to doubles, because they are considered
-        # to have no meaning except when multiplied by the coverage fraction (itself a double)
+        # Unlike values, weights are always coerced to doubles, because they are
+        # considered to have no meaning except when multiplied by the coverage fraction
+        # (itself a double)
         assert len(weights) == 9
         np.testing.assert_array_equal(
             weights.data, [0, 1, 2, 3, 4, 5, float("nan"), 7, 8]
@@ -1473,7 +1460,6 @@ def test_custom_function_not_intersecting():
 
 
 def test_explicit_operation():
-
     rast = NumPyRasterSource(np.arange(9).reshape(3, 3))
     square = make_rect(0.5, 0.5, 2.5, 2.5)
 
@@ -1489,7 +1475,6 @@ def test_explicit_operation():
 
 
 def test_progress():
-
     rast = NumPyRasterSource(np.arange(9).reshape(3, 3))
     square = make_rect(0.5, 0.5, 2.5, 2.5)
 
@@ -1499,7 +1484,6 @@ def test_progress():
 
 
 def test_grid_compat_tol():
-
     values = NumPyRasterSource(
         np.arange(9).reshape(3, 3), xmin=0, xmax=1, ymin=0, ymax=1
     )
@@ -1568,15 +1552,14 @@ def test_crs_mismatch(tmp_path):
 
 
 def test_crs_match_after_normalization(tmp_path):
-
     pytest.importorskip("osgeo.osr")
 
     rast = tmp_path / "test.tif"
     square = tmp_path / "test.shp"
 
-    rast_crs = 'PROJCS["WGS 84 / UTM zone 4N",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-159],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","32604"]]'
+    rast_crs = 'PROJCS["WGS 84 / UTM zone 4N",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-159],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","32604"]]'  # noqa: E501
 
-    vec_crs = 'PROJCRS["WGS 84 / UTM zone 4N",BASEGEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["UTM zone 4N",METHOD["Transverse Mercator",ID["EPSG",9807]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",-159,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["Scale factor at natural origin",0.9996,SCALEUNIT["unity",1],ID["EPSG",8805]],PARAMETER["False easting",500000,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing",north,ORDER[2],LENGTHUNIT["metre",1]],ID["EPSG",32604]]'
+    vec_crs = 'PROJCRS["WGS 84 / UTM zone 4N",BASEGEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4326]],CONVERSION["UTM zone 4N",METHOD["Transverse Mercator",ID["EPSG",9807]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",-159,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["Scale factor at natural origin",0.9996,SCALEUNIT["unity",1],ID["EPSG",8805]],PARAMETER["False easting",500000,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["easting",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["northing",north,ORDER[2],LENGTHUNIT["metre",1]],ID["EPSG",32604]]'  # noqa: E501
 
     create_gdal_raster(rast, np.arange(9).reshape(3, 3), crs=rast_crs)
     create_gdal_features(square, [make_rect(0.5, 0.5, 2.5, 2.5)], crs=vec_crs)
@@ -1588,7 +1571,6 @@ def test_crs_match_after_normalization(tmp_path):
 
 @pytest.fixture()
 def multidim_nc(tmp_path):
-
     gdal = pytest.importorskip("osgeo.gdal")
 
     fname = str(tmp_path / "test_multidim.nc")
@@ -1640,7 +1622,6 @@ def multidim_nc(tmp_path):
 
 @pytest.mark.parametrize("libname", ("gdal", "rasterio", "xarray"))
 def test_gdal_multi_variable(multidim_nc, libname):
-
     square = make_rect(0.5, 0.5, 2.5, 2.5)
 
     rast = open_with_lib(multidim_nc, libname)

--- a/python/tests/test_feature.py
+++ b/python/tests/test_feature.py
@@ -1,5 +1,4 @@
 import pytest
-
 from exactextract.feature import Feature, GDALFeature, JSONFeature
 
 

--- a/python/tests/test_operation.py
+++ b/python/tests/test_operation.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 import pytest
-
 from exactextract import Operation
 
 
@@ -60,6 +58,5 @@ def test_invalid_weights(np_raster_source):
 
 
 def test_stat_arguments(np_raster_source):
-
     op = Operation("quantile", "test", np_raster_source, None, {"q": 0.333})
     assert op.values == np_raster_source

--- a/python/tests/test_processor.py
+++ b/python/tests/test_processor.py
@@ -1,5 +1,4 @@
 import pytest
-
 from exactextract import Operation
 from exactextract.feature import JSONFeatureSource
 from exactextract.processor import FeatureSequentialProcessor, RasterSequentialProcessor

--- a/python/tests/test_raster_source.py
+++ b/python/tests/test_raster_source.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-
 from exactextract.raster import (
     GDALRasterSource,
     RasterioRasterSource,

--- a/python/tests/test_version.py
+++ b/python/tests/test_version.py
@@ -1,17 +1,14 @@
 import re
 
-import pytest
-
 import exactextract
+import pytest
 
 
 def test_version_format():
-
     assert re.match("[0-9]+[.][0-9]+[.][0-9]+", exactextract.__version__)
 
 
 def test_version_consistency():
-
     from importlib.metadata import PackageNotFoundError, version
 
     try:

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-
 from exactextract import Operation
 from exactextract.feature import JSONFeature
 from exactextract.writer import GDALWriter, JSONWriter, PandasWriter, QGISWriter


### PR DESCRIPTION
Many projects move to [ruff](https://docs.astral.sh/ruff/) because:
- you only need one tool for all python linting/formatting as it supports
- it is fast
- very actively developed

Maybe a good idea to transition exactextract linting and formatting to it as well?