### PR TITLE
Add support for returning results as xarray

### DIFF
--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -426,28 +426,48 @@ def exact_extract(
                            which may be significant for operations with large result sizes
                            such as ``cell_id``, ``values``, etc.
                  - "xarray": return as an ``xarray.Dataset`` with dimensions ``(feature, <dim_name>)``.
-                            Recognizes the following ``output_options``: ``dim_name`` (default: ``"band"``) and
-                            ``dim_coords``. When the input raster is an :py:class:`xarray.DataArray` or
-                            :py:class:`xarray.Dataset`, ``dim_coords`` are inferred automatically from ``dim_name``
-                            if that coordinate exists on the input.
+                            When the input is an :py:class:`xarray.DataArray` or :py:class:`xarray.Dataset`
+                            with a single non-spatial dimension, ``dim_name`` and ``dim_coords`` are inferred
+                            automatically. XArrays with multiple non-spatial dimensions will return ValueError. 
+                            For all other raster types, or when the non-spatial dimension has
+                            no coordinates, integer band indices are used. Supports the following
+                            ``output_options``: ``dim_name`` (default: ``"band"``) and ``dim_coords``.
        output_options: an optional dictionary of options passed to the :py:class:`writer.JSONWriter`, :py:class:`writer.PandasWriter`, :py:class:`writer.GDALWriter`, or :py:class:`writer.XArrayWriter`.
        progress: if `True`, a progress bar will be displayed. Alternatively, a
                  function may be provided that will be called with the completion fraction
                  and a status message.
     """
-    # Auto-resolve dim_coords for xarray inputs before prep_raster() converts
+    # Auto-resolve dim_name and dim_coords for xarray inputs before prep_raster() converts
     # them to RasterSource objects (after which the original DataArray is gone).
     if output == "xarray":
         output_options = dict(output_options or {})
-        if "dim_coords" not in output_options:
-            dim_name = output_options.get("dim_name", "band")
-            try:
-                import xarray
-                if isinstance(rast, (xarray.DataArray, xarray.Dataset)):
-                    if dim_name in rast.coords:
-                        output_options["dim_coords"] = rast.coords[dim_name].values
-            except ImportError:
-                pass
+        try:
+            import xarray
+            if isinstance(rast, (xarray.DataArray, xarray.Dataset)):
+                # For xarray, use first non-spatial variable to get dim_name and dim_coords
+                da = rast[next(iter(rast.data_vars))] if isinstance(rast, xarray.Dataset) else rast
+                spatial_dims = {
+                    d for d in da.dims
+                    if d.lower() in ("x", "y", "lon", "lat", "longitude", "latitude")
+                }
+                non_spatial_dims = [d for d in da.dims if d not in spatial_dims]
+
+                if len(non_spatial_dims) > 1:
+                    raise ValueError(
+                        f"XArrayWriter does not support DataArrays with multiple "
+                        f"non-spatial dimensions {non_spatial_dims}. "
+                        "Please select or stack dimensions first."
+                    )
+                
+                if len(non_spatial_dims) == 1:
+                    dim = non_spatial_dims[0]
+                    if "dim_name" not in output_options:
+                        output_options["dim_name"] = dim
+                    if "dim_coords" not in output_options and dim in da.coords:
+                        output_options["dim_coords"] = da.coords[dim].values
+
+        except ImportError:
+            pass
 
     rast = prep_raster(rast)
     weights = prep_raster(weights, name_root="weight")

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -425,10 +425,12 @@ def exact_extract(
                            to maintain results for all features in memory at a single time,
                            which may be significant for operations with large result sizes
                            such as ``cell_id``, ``values``, etc.
-                 - "xarray": return an :py:class:`xarray.Dataset` or :py:class:`xarray.DataArray`,
-                            depending on whether input data contained one or multiple variables. 
-                            Returned dimensions depend on the structure of the input data: ``(feature, stat)``
-                            for single band raster, or ``(feature, band, stat)`` for multi band raster. 
+                 - "xarray": Writer that returns an :py:class:`xarray.Dataset`, with one or more data variables
+                            for each of the computed statistics. 
+                            Returned dimensions depend on the structure of the input raster: ``(feature)`` for 
+                            single variable and single band raster, ``(feature, band)`` for single variable and 
+                            multi band raster, ``(feature, var)`` for multi variable and single band raster, and 
+                            ``(feature, var, band)`` for multi variable and multi band raster. 
        output_options: an optional dictionary of options passed to the :py:class:`writer.JSONWriter`, :py:class:`writer.PandasWriter`, :py:class:`writer.GDALWriter`, or :py:class:`writer.XArrayWriter`.
        progress: if `True`, a progress bar will be displayed. Alternatively, a
                  function may be provided that will be called with the completion fraction

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -425,50 +425,15 @@ def exact_extract(
                            to maintain results for all features in memory at a single time,
                            which may be significant for operations with large result sizes
                            such as ``cell_id``, ``values``, etc.
-                 - "xarray": return as an ``xarray.Dataset`` with dimensions ``(feature, <dim_name>)``.
-                            When the input is an :py:class:`xarray.DataArray` or :py:class:`xarray.Dataset`
-                            with a single non-spatial dimension, ``dim_name`` and ``dim_coords`` are inferred
-                            automatically. XArrays with multiple non-spatial dimensions will return ValueError. 
-                            For all other raster types, or when the non-spatial dimension has
-                            no coordinates, integer band indices are used. Supports the following
-                            ``output_options``: ``dim_name`` (default: ``"band"``) and ``dim_coords``.
+                 - "xarray": return an :py:class:`xarray.Dataset` or :py:class:`xarray.DataArray`,
+                            depending on whether input data contained one or multiple variables. 
+                            Returned dimensions depend on the structure of the input data: ``(feature, stat)``
+                            for single band raster, or ``(feature, band, stat)`` for multi band raster. 
        output_options: an optional dictionary of options passed to the :py:class:`writer.JSONWriter`, :py:class:`writer.PandasWriter`, :py:class:`writer.GDALWriter`, or :py:class:`writer.XArrayWriter`.
        progress: if `True`, a progress bar will be displayed. Alternatively, a
                  function may be provided that will be called with the completion fraction
                  and a status message.
     """
-    # Auto-resolve dim_name and dim_coords for xarray inputs before prep_raster() converts
-    # them to RasterSource objects (after which the original DataArray is gone).
-    if output == "xarray":
-        output_options = dict(output_options or {})
-        try:
-            import xarray
-            if isinstance(rast, (xarray.DataArray, xarray.Dataset)):
-                # For xarray, use first non-spatial variable to get dim_name and dim_coords
-                da = rast[next(iter(rast.data_vars))] if isinstance(rast, xarray.Dataset) else rast
-                spatial_dims = {
-                    d for d in da.dims
-                    if d.lower() in ("x", "y", "lon", "lat", "longitude", "latitude")
-                }
-                non_spatial_dims = [d for d in da.dims if d not in spatial_dims]
-
-                if len(non_spatial_dims) > 1:
-                    raise ValueError(
-                        f"XArrayWriter does not support DataArrays with multiple "
-                        f"non-spatial dimensions {non_spatial_dims}. "
-                        "Please select or stack dimensions first."
-                    )
-                
-                if len(non_spatial_dims) == 1:
-                    dim = non_spatial_dims[0]
-                    if "dim_name" not in output_options:
-                        output_options["dim_name"] = dim
-                    if "dim_coords" not in output_options and dim in da.coords:
-                        output_options["dim_coords"] = da.coords[dim].values
-
-        except ImportError:
-            pass
-
     rast = prep_raster(rast)
     weights = prep_raster(weights, name_root="weight")
     vec = prep_vec(vec)

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -430,6 +430,20 @@ def exact_extract(
                  function may be provided that will be called with the completion fraction
                  and a status message.
     """
+    # Auto-resolve dim_coords for xarray inputs before prep_raster() converts
+    # them to RasterSource objects (after which the original DataArray is gone).
+    if output == "xarray":
+        output_options = dict(output_options or {})
+        if "dim_coords" not in output_options:
+            dim_name = output_options.get("dim_name", "band")
+            try:
+                import xarray
+                if isinstance(rast, (xarray.DataArray, xarray.Dataset)):
+                    if dim_name in rast.coords:
+                        output_options["dim_coords"] = rast.coords[dim_name].values
+            except ImportError:
+                pass
+
     rast = prep_raster(rast)
     weights = prep_raster(weights, name_root="weight")
     vec = prep_vec(vec)

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -425,7 +425,12 @@ def exact_extract(
                            to maintain results for all features in memory at a single time,
                            which may be significant for operations with large result sizes
                            such as ``cell_id``, ``values``, etc.
-       output_options: an optional dictionary of options passed to the :py:class:`writer.JSONWriter`, :py:class:`writer.PandasWriter`, or :py:class:`writer.GDALWriter`.
+                 - "xarray": return as an ``xarray.Dataset`` with dimensions ``(feature, <dim_name>)``.
+                            Recognizes the following ``output_options``: ``dim_name`` (default: ``"band"``) and
+                            ``dim_coords``. When the input raster is an :py:class:`xarray.DataArray` or
+                            :py:class:`xarray.Dataset`, ``dim_coords`` are inferred automatically from ``dim_name``
+                            if that coordinate exists on the input.
+       output_options: an optional dictionary of options passed to the :py:class:`writer.JSONWriter`, :py:class:`writer.PandasWriter`, :py:class:`writer.GDALWriter`, or :py:class:`writer.XArrayWriter`.
        progress: if `True`, a progress bar will be displayed. Alternatively, a
                  function may be provided that will be called with the completion fraction
                  and a status message.

--- a/python/src/exactextract/exact_extract.py
+++ b/python/src/exactextract/exact_extract.py
@@ -20,7 +20,7 @@ from .raster import (
     RasterSource,
     XArrayRasterSource,
 )
-from .writer import GDALWriter, JSONWriter, PandasWriter, QGISWriter, Writer
+from .writer import GDALWriter, JSONWriter, PandasWriter, QGISWriter, Writer, XArrayWriter
 
 __all__ = ["exact_extract"]
 
@@ -290,6 +290,8 @@ def prep_writer(output, srs_wkt, options):
         return QGISWriter(srs_wkt=srs_wkt, **options)
     elif output == "gdal":
         return GDALWriter(srs_wkt=srs_wkt, **options)
+    elif output == "xarray":
+        return XArrayWriter(**options)
 
     raise Exception("Unsupported value of output")
 

--- a/python/src/exactextract/writer.py
+++ b/python/src/exactextract/writer.py
@@ -478,34 +478,37 @@ class XArrayWriter(Writer):
             # - variables and statistics: var1_mean, var1_sum, etc
             # - variables and bands and statistics: var1_band_1_mean, var1_band_1_sum, etc
             prop = op.name
-            stat = op.stat
             value = props.get(prop, None)  # sometimes statistic is missing from props
-            row = {"feature": feature_index, "value": value, "stat": stat}
-
-            # validate that the prop name ends with statistic
-            if not prop.endswith(stat):
-                raise Exception(f'Statistics operation field name should end with "{stat}", not "{prop}"')
-
-            # remove stat from right side of prop string to get the prefix
-            prefix = prop.removesuffix(stat).strip('_')
+            row = {"feature": feature_index, "value": value}
             
-            # if there is any prefix left it should follow strict conventions
-            if prefix:
-                # if prefix starts with band_ then that should be the only component
-                if prefix.startswith('band_'):
-                    _, band = prefix.split('_')
-                    row['band'] = int(band)
+            # if prop starts with band_, then that should be used to split into band and stat
+            if prop.startswith('band_'):
+                parts = prop.split('_')
+                band = parts[1]
+                stat = '_'.join(parts[2:])
+                row['band'] = int(band)
+                row['stat'] = stat
 
-                # if prefix contains _band_ then that should be used to split into varname and band
-                elif '_band_' in prefix:
-                    varname, band = prefix.split('_band_')
-                    row['var'] = varname
-                    row['band'] = int(band)
+            # if prop contains _band_ then that should be used to split into varname, band and stat
+            elif '_band_' in prop:
+                varname, band_plus_stat = prop.split('_band_')
+                parts = band_plus_stat.split('_')
+                band = parts[0]
+                stat = '_'.join(parts[1:])
+                row['var'] = varname
+                row['band'] = int(band)
+                row['stat'] = stat
 
-                # prefix should be varname only
-                else:
-                    varname = prefix
-                    row['var'] = varname
+            # prop should be varname and stat only
+            else:
+                # Note: stat may include additional parts based on kwargs, eg quantile_25
+                stat_pos = prop.find(op.stat)
+                if stat_pos == -1:
+                    raise ValueError(f'Unable to parse {op.stat} statistic from field name {prop}')
+                varname = prop[:stat_pos].strip('_')
+                stat = prop[stat_pos:]
+                row['var'] = varname
+                row['stat'] = stat
 
             self.records.append(row)
 

--- a/python/src/exactextract/writer.py
+++ b/python/src/exactextract/writer.py
@@ -420,3 +420,104 @@ class GDALWriter(Writer):
                 ogr_fields[field_name] = ogr.FieldDefn(field_name, field_type)
 
         return ogr_fields
+
+class XArrayWriter(Writer):
+    """
+    Writer that returns an :py:class:`xarray.Dataset` with dimensions
+    ``(feature, <dim_name>)``.
+
+    Unlike the other writers, the non-spatial dimension (e.g. time) cannot
+    be inferred from exactextract's internal data model, which only tracks
+    band indices. When the input raster is an :py:class:`xarray.DataArray`
+    or :py:class:`xarray.Dataset`, ``dim_coords`` are resolved automatically
+    by :py:func:`exact_extract` if ``dim_name`` matches a coordinate on the
+    input. For all other raster types, integer band indices are used unless
+    ``dim_coords`` is provided explicitly via ``output_options``.
+
+    Args:
+        dim_name: Name of the non-spatial output dimension. Defaults to
+            ``"band"``. Common values: ``"time"``, ``"level"``.
+        dim_coords: Coordinate values for the non-spatial dimension, one per
+            band in the source raster (e.g. ``ds["time"].values``). If not
+            provided, 0-based integer indices are used.
+    """
+
+    def __init__(self, *, dim_name="band", dim_coords=None):
+        self._dim_name = dim_name
+        self._dim_coords = dim_coords
+        self._ops = []
+        self._id_cols = []
+        self._rows = []
+
+    def add_operation(self, op):
+        self._ops.append(op)
+
+    def add_column(self, col_name):
+        self._id_cols.append(col_name)
+
+    def write(self, feature):
+        props = feature["properties"]
+        row = {col: props.get(col) for col in self._id_cols}
+        for op in self._ops:
+            row[op.name] = props.get(op.name)
+        self._rows.append(row)
+
+    def features(self):
+        import numpy as np
+        import xarray as xr
+        from collections import defaultdict
+
+        if not self._rows:
+            return xr.Dataset()
+
+        feature_ids = (
+            [r[self._id_cols[0]] for r in self._rows]
+            if self._id_cols
+            else list(range(len(self._rows)))
+        )
+
+        # Group ops by (var_name, stat) — each group spans one full set of bands
+        groups = defaultdict(list)
+        for op in self._ops:
+            var_name = (op.values.name or "").strip("_") or "values"
+            groups[(var_name, op.stat)].append(op)
+
+        # All groups must have the same number of bands
+        group_lengths = {len(ops) for ops in groups.values()}
+        if len(group_lengths) != 1:
+            raise ValueError(
+                f"Unequal number of bands across stat/variable groups: {group_lengths}"
+            )
+        n_bands = group_lengths.pop()
+
+        dim_coords = (
+            np.asarray(self._dim_coords)
+            if self._dim_coords is not None
+            else np.arange(n_bands)
+        )
+
+        if len(dim_coords) != n_bands:
+            raise ValueError(
+                f"Length of dim_coords ({len(dim_coords)}) does not match "
+                f"number of bands per group ({n_bands})."
+            )
+
+        # Use plain var_name when there is only one stat, var_name_stat otherwise
+        multi_stat = len({stat for _, stat in groups}) > 1
+
+        data_vars = {}
+        for (var_name, stat), ops in groups.items():
+            da_name = f"{var_name}_{stat}" if multi_stat else var_name
+            data = np.array(
+                [[r[op.name] for op in ops] for r in self._rows],
+                dtype=float,
+            )
+            data_vars[da_name] = (["feature", self._dim_name], data)
+
+        return xr.Dataset(
+            data_vars,
+            coords={
+                self._dim_name: dim_coords,
+                "feature": feature_ids,
+            },
+        )

--- a/python/src/exactextract/writer.py
+++ b/python/src/exactextract/writer.py
@@ -423,10 +423,12 @@ class GDALWriter(Writer):
 
 class XArrayWriter(Writer):
     """
-    Writer that returns an :py:class:`xarray.Dataset` or :py:class:`xarray.DataArray`,
-    depending on whether input data contained one or multiple variables. 
-    Returned dimensions depend on the structure of the input data: ``(feature, stat)``
-    for single band raster, or ``(feature, band, stat)`` for multi band raster. 
+    Writer that returns an :py:class:`xarray.Dataset`, with one or more data variables
+    for each of the computed statistics. 
+    Returned dimensions depend on the structure of the input raster: ``(feature)`` for single variable and single band 
+    raster, ``(feature, band)`` for single variable and multi band raster, 
+    ``(feature, var)`` for multi variable and single band raster, and ``(feature, var, band)``
+    for multi variable and multi band raster. 
     If the input raster has multiple dimensions (e.g. time x level), band numbering follows 
     the same logic as other Writers, bands are enumerated in C-order (last dimension varies 
     fastest), matching the order returned by ``rasterio.count``.
@@ -513,21 +515,22 @@ class XArrayWriter(Writer):
         import pandas as pd
         df = pd.DataFrame(self.records)
         
-        # set multiindex to what we want as xarray dims
-        dim_cols = [c for c in df.columns if c != "value"]
-        df = df.set_index(dim_cols)
+        # get which xarray dims to keep
+        dim_cols = [c for c in df.columns if c not in ("value", "stat")]
+
+        # pivot stat into columns
+        df = df.pivot_table(
+            index=dim_cols,
+            columns="stat",
+            values="value",
+        )
+
+        # drop var from index if only one unique value
+        if "var" in df.index.names and df.index.get_level_values("var").nunique() == 1:
+            df = df.droplevel("var")
 
         # convert to xarray
-        if "var" in df.index.names:
-            # xarray Dataset with one DataArray per "var"
-            d = (
-                df["value"]
-                .to_xarray()
-                .to_dataset(dim="var")
-            )
-        else:
-            # single xarray DataArray
-            d = df["value"].to_xarray()
+        ds = df.to_xarray()
 
         # assign extra columns as coords
         # all extra columns are based on the feature dimension
@@ -538,6 +541,6 @@ class XArrayWriter(Writer):
                 for col, col_values
                 in self.extra_cols.items()
             }
-            d = d.assign_coords(**coords)
+            ds = ds.assign_coords(**coords)
 
-        return d
+        return ds

--- a/python/src/exactextract/writer.py
+++ b/python/src/exactextract/writer.py
@@ -467,7 +467,7 @@ class XArrayWriter(Writer):
                 value = props[col]
             self.extra_cols[col].append(value)
 
-        # all we have is a number of operations corresponding to properties per feature
+        # all we have is a list of operations corresponding to properties per feature
         # each operation/property name encodes dimensions: statistic, band, and variable
         # and its data value and dimension values should be added as a dict to .records
         for op in self.ops:
@@ -478,35 +478,34 @@ class XArrayWriter(Writer):
             # - variables and statistics: var1_mean, var1_sum, etc
             # - variables and bands and statistics: var1_band_1_mean, var1_band_1_sum, etc
             prop = op.name
-            value = props[prop]
-            row = {"feature": feature_index, "value": value}
+            stat = op.stat
+            value = props.get(prop, None)  # sometimes statistic is missing from props
+            row = {"feature": feature_index, "value": value, "stat": stat}
 
-            # Note: below relies on strict naming conventions and number of underscores
-            # meaning variables or operation names cannot have underscores in them
-            # TODO: Make this more robust... 
-            prop_parts = prop.split('_')
-            if len(prop_parts) == 1:
-                # single statistic
-                stat = prop
-                row.update({"stat": stat})
+            # validate that the prop name ends with statistic
+            if not prop.endswith(stat):
+                raise Exception(f'Statistics operation field name should end with "{stat}", not "{prop}"')
 
-            elif len(prop_parts) == 2:
-                # variable + statistic
-                varname, stat = prop_parts
-                row.update({"var": varname, "stat": stat})
+            # remove stat from right side of prop string to get the prefix
+            prefix = prop.removesuffix(stat).strip('_')
+            
+            # if there is any prefix left it should follow strict conventions
+            if prefix:
+                # if prefix starts with band_ then that should be the only component
+                if prefix.startswith('band_'):
+                    _, band = prefix.split('_')
+                    row['band'] = int(band)
 
-            elif len(prop_parts) == 3:
-                # band (band_1 etc) + statistic
-                _, band, stat = prop_parts
-                row.update({"band": int(band), "stat": stat})
+                # if prefix contains _band_ then that should be used to split into varname and band
+                elif '_band_' in prefix:
+                    varname, band = prefix.split('_band_')
+                    row['var'] = varname
+                    row['band'] = int(band)
 
-            elif len(prop_parts) == 4:
-                # variable + band (band_1 etc) + statistic
-                varname, _, band, stat = prop_parts
-                row.update({"var": varname, "band": int(band), "stat": stat})
-
-            else:
-                raise ValueError(f"Unexpected property name format: {prop!r}")
+                # prefix should be varname only
+                else:
+                    varname = prefix
+                    row['var'] = varname
 
             self.records.append(row)
 
@@ -523,6 +522,7 @@ class XArrayWriter(Writer):
             index=dim_cols,
             columns="stat",
             values="value",
+            dropna=False,
         )
 
         # drop var from index if only one unique value

--- a/python/src/exactextract/writer.py
+++ b/python/src/exactextract/writer.py
@@ -443,6 +443,7 @@ class XArrayWriter(Writer):
     """
 
     def __init__(self, *, dim_name="band", dim_coords=None):
+        super().__init__()
         self._dim_name = dim_name
         self._dim_coords = dim_coords
         self._ops = []
@@ -456,7 +457,10 @@ class XArrayWriter(Writer):
         self._id_cols.append(col_name)
 
     def write(self, feature):
-        props = feature["properties"]
+        f = JSONFeature()
+        feature.copy_to(f);
+
+        props = f.feature["properties"]
         row = {col: props.get(col) for col in self._id_cols}
         for op in self._ops:
             row[op.name] = props.get(op.name)
@@ -466,6 +470,7 @@ class XArrayWriter(Writer):
         import numpy as np
         import xarray as xr
         from collections import defaultdict
+        import re
 
         if not self._rows:
             return xr.Dataset()
@@ -479,8 +484,13 @@ class XArrayWriter(Writer):
         # Group ops by (var_name, stat) — each group spans one full set of bands
         groups = defaultdict(list)
         for op in self._ops:
-            var_name = (op.values.name or "").strip("_") or "values"
-            groups[(var_name, op.stat)].append(op)
+            stat = op.stat
+            suffix = f"_{stat}"
+            prefix = op.name[:-len(suffix)] if op.name.endswith(suffix) else op.name
+            # prefix is e.g. "t2m_band_1", "band_1", "t2m", ""
+            # strip band index to get var name
+            var_name = re.sub(r"_?band_\d+$", "", prefix) or "values"
+            groups[(var_name, stat)].append(op)
 
         # All groups must have the same number of bands
         group_lengths = {len(ops) for ops in groups.values()}

--- a/python/src/exactextract/writer.py
+++ b/python/src/exactextract/writer.py
@@ -443,11 +443,9 @@ class XArrayWriter(Writer):
         self.feature_count = 0
 
     def add_operation(self, op):
-        # this should later become a special operation/stat dimension
         self.ops.append(op)
 
     def add_column(self, col_name):
-        # all other columns should become their own dimensions
         self.extra_cols[col_name] = []
 
     def write(self, feature):

--- a/python/src/exactextract/writer.py
+++ b/python/src/exactextract/writer.py
@@ -499,16 +499,22 @@ class XArrayWriter(Writer):
                 row['band'] = int(band)
                 row['stat'] = stat
 
-            # prop should be varname and stat only
+            # prop should be stat and optionally varname
             else:
-                # Note: stat may include additional parts based on kwargs, eg quantile_25
+                # search for first string instance of stat
                 stat_pos = prop.find(op.stat)
                 if stat_pos == -1:
                     raise ValueError(f'Unable to parse {op.stat} statistic from field name {prop}')
-                varname = prop[:stat_pos].strip('_')
+                
+                # extract full stat name starting at first string instance
+                # eg stat may include additional parts based on kwargs, eg quantile_25
                 stat = prop[stat_pos:]
-                row['var'] = varname
                 row['stat'] = stat
+
+                # if stat starts in middle of string, then first part is varname
+                if stat_pos > 0:
+                    varname = prop[:stat_pos].strip('_')
+                    row['var'] = varname
 
             self.records.append(row)
 

--- a/python/src/exactextract/writer.py
+++ b/python/src/exactextract/writer.py
@@ -423,111 +423,121 @@ class GDALWriter(Writer):
 
 class XArrayWriter(Writer):
     """
-    Writer that returns an :py:class:`xarray.Dataset` with dimensions
-    ``(feature, <dim_name>)``.
-
-    Unlike the other writers, the non-spatial dimension (e.g. time) cannot
-    be inferred from exactextract's internal data model, which only tracks
-    band indices. When the input raster is an :py:class:`xarray.DataArray`
-    or :py:class:`xarray.Dataset`, ``dim_coords`` are resolved automatically
-    by :py:func:`exact_extract` if ``dim_name`` matches a coordinate on the
-    input. For all other raster types, integer band indices are used unless
-    ``dim_coords`` is provided explicitly via ``output_options``.
-
-    Args:
-        dim_name: Name of the non-spatial output dimension. Defaults to
-            ``"band"``. Common values: ``"time"``, ``"level"``.
-        dim_coords: Coordinate values for the non-spatial dimension, one per
-            band in the source raster (e.g. ``ds["time"].values``). If not
-            provided, 0-based integer indices are used.
+    Writer that returns an :py:class:`xarray.Dataset` or :py:class:`xarray.DataArray`,
+    depending on whether input data contained one or multiple variables. 
+    Returned dimensions depend on the structure of the input data: ``(feature, stat)``
+    for single band raster, or ``(feature, band, stat)`` for multi band raster. 
+    If the input raster has multiple dimensions (e.g. time x level), band numbering follows 
+    the same logic as other Writers, bands are enumerated in C-order (last dimension varies 
+    fastest), matching the order returned by ``rasterio.count``.
     """
 
-    def __init__(self, *, dim_name="band", dim_coords=None):
+    def __init__(self):
         super().__init__()
-        self._dim_name = dim_name
-        self._dim_coords = dim_coords
-        self._ops = []
-        self._id_cols = []
-        self._rows = []
+
+        self.ops = []
+        self.extra_cols = {}
+        self.records = []
+        self.feature_count = 0
 
     def add_operation(self, op):
-        self._ops.append(op)
+        # this should later become a special operation/stat dimension
+        self.ops.append(op)
 
     def add_column(self, col_name):
-        self._id_cols.append(col_name)
+        # all other columns should become their own dimensions
+        self.extra_cols[col_name] = []
 
     def write(self, feature):
         f = JSONFeature()
-        feature.copy_to(f);
-
+        feature.copy_to(f)
         props = f.feature["properties"]
-        row = {col: props.get(col) for col in self._id_cols}
-        for op in self._ops:
-            row[op.name] = props.get(op.name)
-        self._rows.append(row)
+
+        # get feature index
+        self.feature_count += 1
+        feature_index = int(self.feature_count)
+
+        # add any extra column values
+        for col in self.extra_cols:
+            if col == 'id' and 'id' in f.feature:
+                value = f.feature["id"]
+            else:
+                value = props[col]
+            self.extra_cols[col].append(value)
+
+        # all we have is a number of operations corresponding to properties per feature
+        # each operation/property name encodes dimensions: statistic, band, and variable
+        # and its data value and dimension values should be added as a dict to .records
+        for op in self.ops:
+            # extract misc dims from operation property name
+            # possible operation property templates:
+            # - statistics: mean, sum, etc
+            # - bands and statistics: band_1_mean, band_1_sum, etc
+            # - variables and statistics: var1_mean, var1_sum, etc
+            # - variables and bands and statistics: var1_band_1_mean, var1_band_1_sum, etc
+            prop = op.name
+            value = props[prop]
+            row = {"feature": feature_index, "value": value}
+
+            # Note: below relies on strict naming conventions and number of underscores
+            # meaning variables or operation names cannot have underscores in them
+            # TODO: Make this more robust... 
+            prop_parts = prop.split('_')
+            if len(prop_parts) == 1:
+                # single statistic
+                stat = prop
+                row.update({"stat": stat})
+
+            elif len(prop_parts) == 2:
+                # variable + statistic
+                varname, stat = prop_parts
+                row.update({"var": varname, "stat": stat})
+
+            elif len(prop_parts) == 3:
+                # band (band_1 etc) + statistic
+                _, band, stat = prop_parts
+                row.update({"band": int(band), "stat": stat})
+
+            elif len(prop_parts) == 4:
+                # variable + band (band_1 etc) + statistic
+                varname, _, band, stat = prop_parts
+                row.update({"var": varname, "band": int(band), "stat": stat})
+
+            else:
+                raise ValueError(f"Unexpected property name format: {prop!r}")
+
+            self.records.append(row)
 
     def features(self):
-        import numpy as np
-        import xarray as xr
-        from collections import defaultdict
-        import re
+        # make pandas df from dict records
+        import pandas as pd
+        df = pd.DataFrame(self.records)
+        
+        # set multiindex to what we want as xarray dims
+        dim_cols = [c for c in df.columns if c != "value"]
+        df = df.set_index(dim_cols)
 
-        if not self._rows:
-            return xr.Dataset()
-
-        feature_ids = (
-            [r[self._id_cols[0]] for r in self._rows]
-            if self._id_cols
-            else list(range(len(self._rows)))
-        )
-
-        # Group ops by (var_name, stat) — each group spans one full set of bands
-        groups = defaultdict(list)
-        for op in self._ops:
-            stat = op.stat
-            suffix = f"_{stat}"
-            prefix = op.name[:-len(suffix)] if op.name.endswith(suffix) else op.name
-            # prefix is e.g. "t2m_band_1", "band_1", "t2m", ""
-            # strip band index to get var name
-            var_name = re.sub(r"_?band_\d+$", "", prefix) or "values"
-            groups[(var_name, stat)].append(op)
-
-        # All groups must have the same number of bands
-        group_lengths = {len(ops) for ops in groups.values()}
-        if len(group_lengths) != 1:
-            raise ValueError(
-                f"Unequal number of bands across stat/variable groups: {group_lengths}"
+        # convert to xarray
+        if "var" in df.index.names:
+            # xarray Dataset with one DataArray per "var"
+            d = (
+                df["value"]
+                .to_xarray()
+                .to_dataset(dim="var")
             )
-        n_bands = group_lengths.pop()
+        else:
+            # single xarray DataArray
+            d = df["value"].to_xarray()
 
-        dim_coords = (
-            np.asarray(self._dim_coords)
-            if self._dim_coords is not None
-            else np.arange(n_bands)
-        )
+        # assign extra columns as coords
+        # all extra columns are based on the feature dimension
+        if self.extra_cols:
+            col_dim = 'feature'
+            coords = {
+                col: (col_dim, col_values)
+                for col, col_values
+                in self.extra_cols.items()
+            }
+            d = d.assign_coords(**coords)
 
-        if len(dim_coords) != n_bands:
-            raise ValueError(
-                f"Length of dim_coords ({len(dim_coords)}) does not match "
-                f"number of bands per group ({n_bands})."
-            )
-
-        # Use plain var_name when there is only one stat, var_name_stat otherwise
-        multi_stat = len({stat for _, stat in groups}) > 1
-
-        data_vars = {}
-        for (var_name, stat), ops in groups.items():
-            da_name = f"{var_name}_{stat}" if multi_stat else var_name
-            data = np.array(
-                [[r[op.name] for op in ops] for r in self._rows],
-                dtype=float,
-            )
-            data_vars[da_name] = (["feature", self._dim_name], data)
-
-        return xr.Dataset(
-            data_vars,
-            coords={
-                self._dim_name: dim_coords,
-                "feature": feature_ids,
-            },
-        )
+        return d

--- a/python/tests/test_exact_extract.py
+++ b/python/tests/test_exact_extract.py
@@ -58,7 +58,7 @@ def use_gdal_exceptions():
         gdal.UseExceptions()
 
 
-@pytest.mark.parametrize("output_format", ("geojson", "pandas"), indirect=True)
+@pytest.mark.parametrize("output_format", ("geojson", "pandas", "xarray"), indirect=True)
 @pytest.mark.parametrize(
     "stat,expected",
     [
@@ -110,6 +110,8 @@ def test_basic_stats(stat, expected, output_format):
 
     if output_format == "geojson":
         value = result[0]["properties"][stat]
+    elif output_format == "xarray":
+        value = result[stat].values[0]
     else:
         value = result[stat][0]
 
@@ -196,7 +198,7 @@ def test_coverage_area(strategy):
     assert np.all(result["c4"] == result["c1"])
 
 
-@pytest.mark.parametrize("output_format", ("geojson", "pandas"), indirect=True)
+@pytest.mark.parametrize("output_format", ("geojson", "pandas", "xarray"), indirect=True)
 def test_multiple_stats(output_format):
     rast = NumPyRasterSource(np.arange(1, 10).reshape(3, 3))
     square = JSONFeatureSource(make_rect(0.5, 0.5, 2.5, 2.5))
@@ -205,6 +207,11 @@ def test_multiple_stats(output_format):
 
     if output_format == "geojson":
         fields = result[0]["properties"]
+    elif output_format == "xarray":
+        fields = {
+            var: float(result[var].isel(feature=0).values)
+            for var in result.data_vars
+        }
     else:
         fields = result.to_dict(orient="records")[0]
 
@@ -594,6 +601,20 @@ def test_all_nodata_gdal():
     assert math.isnan(features[1]["mean"])
     assert features[1]["variety"] == 0
     assert features[1]["mode"] is None
+
+
+def test_all_nodata_xarray():
+    pytest.importorskip("xarray")
+
+    data = np.full((3, 3), -999, dtype=np.int32)
+    rast = NumPyRasterSource(data, nodata=-999)
+
+    square = make_rect(0.5, 0.5, 2.5, 2.5)
+    results = exact_extract(rast, square, ["mean", "mode", "variety"], output="xarray")
+
+    assert math.isnan(results["mean"].values[0])
+    assert results["variety"].values[0] == 0
+    assert results["mode"].values[0] is None
 
 
 def test_default_value():
@@ -1105,6 +1126,35 @@ def test_geopandas_output():
     assert result.area[0] == 9
 
     assert "Vermont" in str(result.geometry.crs)
+
+
+def test_xarray_output():
+    xr = pytest.importorskip("xarray")
+    osr = pytest.importorskip("osgeo.osr")
+
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(32145)
+
+    rast = NumPyRasterSource(
+        np.arange(1, 10, dtype=np.int32).reshape(3, 3), srs_wkt=srs.ExportToWkt()
+    )
+
+    square = JSONFeatureSource(
+        make_rect(0, 0, 3, 3, properties={"name": "test"}), srs_wkt=srs.ExportToWkt()
+    )
+
+    result = exact_extract(
+        rast,
+        square,
+        ["mean", "count", "variety"],
+        include_cols=["name"],
+        output="xarray",
+        include_geom=True,  # this will just be silently ignored since xarray cannot store geometries
+    )
+
+    assert isinstance(result, xr.DataArray)
+    assert result['count'].values[0] == 9
+    assert result['name'].values[0] == 'test'
 
 
 def test_qgis_output():

--- a/python/tests/test_exact_extract.py
+++ b/python/tests/test_exact_extract.py
@@ -613,8 +613,8 @@ def test_all_nodata_xarray():
     results = exact_extract(rast, square, ["mean", "mode", "variety"], output="xarray")
 
     assert math.isnan(results["mean"].values[0])
+    assert math.isnan(results["mode"].values[0])
     assert results["variety"].values[0] == 0
-    assert results["mode"].values[0] is None
 
 
 def test_default_value():

--- a/python/tests/test_exact_extract.py
+++ b/python/tests/test_exact_extract.py
@@ -1152,7 +1152,7 @@ def test_xarray_output():
         include_geom=True,  # this will just be silently ignored since xarray cannot store geometries
     )
 
-    assert isinstance(result, xr.DataArray)
+    assert isinstance(result, xr.Dataset)
     assert result['count'].values[0] == 9
     assert result['name'].values[0] == 'test'
 
@@ -1711,6 +1711,25 @@ def test_gdal_multi_variable(multidim_nc, libname):
             "t2m_band_1_count": 4.0,
         }
     )
+
+
+@pytest.mark.parametrize("libname", ("gdal", "rasterio", "xarray"))
+def test_gdal_multi_variable_xarray_output(multidim_nc, libname):
+
+    square = make_rect(0.5, 0.5, 2.5, 2.5)
+
+    rast = open_with_lib(multidim_nc, libname)
+
+    results = exact_extract(rast, square, ["count", "sum"], output='xarray')
+
+    assert results['sum'].sel(var='tp', band=1).values[0] == pytest.approx(10.437034457921982)
+    assert results['sum'].sel(var='tp', band=2).values[0] == pytest.approx(17.4051194190979)
+    assert results['sum'].sel(var='t2m', band=1).values[0] == pytest.approx(28.0)
+    assert results['count'].sel(var='tp', band=2).values[0] == pytest.approx(4.0)
+    assert results['sum'].sel(var='t2m', band=2).values[0] == pytest.approx(76.0)
+    assert results['count'].sel(var='tp', band=1).values[0] == pytest.approx(4.0)
+    assert results['count'].sel(var='t2m', band=2).values[0] == pytest.approx(4.0)
+    assert results['count'].sel(var='t2m', band=1).values[0] == pytest.approx(4.0)
 
 
 @pytest.mark.parametrize("strategy", ("feature-sequential", "raster-sequential"))

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -214,8 +214,8 @@ def test_xarray_writer_band_stat(np_raster_source, point_features):
     w.add_column("id")
     w.add_operation(Operation("mean", "band_1_mean", np_raster_source))
     w.add_operation(Operation("mean", "band_2_mean", np_raster_source))
-    w.add_operation(Operation("mean", "band_1_sum", np_raster_source))
-    w.add_operation(Operation("mean", "band_2_sum", np_raster_source))
+    w.add_operation(Operation("sum", "band_1_sum", np_raster_source))
+    w.add_operation(Operation("sum", "band_2_sum", np_raster_source))
 
     for f in point_features:
         f.feature["properties"]["band_1_mean"] = float(f.feature["id"])

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -195,14 +195,16 @@ def test_xarray_writer_stat(np_raster_source, point_features):
         f.feature["properties"]["sum"] = float(f.feature["id"]) * 2
         w.write(f)
 
-    da = w.features()
+    ds = w.features()
 
-    assert isinstance(da, xr.DataArray)
-    assert len(da.coords["feature"]) == 2
-    assert len(da.coords["id"]) == 2
-    assert 'mean' in da.coords["stat"]
-    assert 'sum' in da.coords["stat"]
-    assert "band" not in da.coords
+    assert isinstance(ds, xr.Dataset)
+
+    assert len(ds.coords["feature"]) == 2
+    assert len(ds.coords["id"]) == 2
+
+    assert 'mean' in ds.data_vars
+    assert 'sum' in ds.data_vars
+    assert ds["mean"].dims == ("feature",)
 
 def test_xarray_writer_band_stat(np_raster_source, point_features):
     xr = pytest.importorskip("xarray")
@@ -222,14 +224,17 @@ def test_xarray_writer_band_stat(np_raster_source, point_features):
         f.feature["properties"]["band_2_sum"] = float(f.feature["id"]) * 2
         w.write(f)
 
-    da = w.features()
+    ds = w.features()
 
-    assert isinstance(da, xr.DataArray)
-    assert len(da.coords["feature"]) == 2
-    assert len(da.coords["id"]) == 2
-    assert len(da.coords["band"]) == 2
-    assert 'mean' in da.coords["stat"]
-    assert 'sum' in da.coords["stat"]
+    assert isinstance(ds, xr.Dataset)
+
+    assert len(ds.coords["feature"]) == 2
+    assert len(ds.coords["id"]) == 2
+    assert len(ds.coords["band"]) == 2
+
+    assert 'mean' in ds.data_vars
+    assert 'sum' in ds.data_vars
+    assert ds["mean"].dims == ("feature", "band")
 
 def test_xarray_writer_var_stat(np_raster_source, point_features):
     xr = pytest.importorskip("xarray")
@@ -252,13 +257,14 @@ def test_xarray_writer_var_stat(np_raster_source, point_features):
     ds = w.features()
 
     assert isinstance(ds, xr.Dataset)
+
     assert len(ds.coords["feature"]) == 2
     assert len(ds.coords["id"]) == 2
-    assert "band" not in ds.coords
-    assert 'mean' in ds.coords["stat"]
-    assert 'sum' in ds.coords["stat"]
-    assert ds["t2m"].dims == ("feature", "stat")
-    assert ds["tp"].dims == ("feature", "stat")
+    assert len(ds.coords["var"]) == 2
+
+    assert 'mean' in ds.data_vars
+    assert 'sum' in ds.data_vars
+    assert ds["mean"].dims == ("feature", "var")
 
 
 def test_xarray_writer_var_band_stat(np_raster_source, point_features):
@@ -282,11 +288,14 @@ def test_xarray_writer_var_band_stat(np_raster_source, point_features):
     ds = w.features()
 
     assert isinstance(ds, xr.Dataset)
+
     assert len(ds.coords["feature"]) == 2
     assert len(ds.coords["id"]) == 2
-    assert 'mean' in ds.coords["stat"]
-    assert ds["t2m"].dims == ("feature", "band", "stat")
-    assert ds["tp"].dims == ("feature", "band", "stat")
+    assert len(ds.coords["var"]) == 2
+    assert len(ds.coords["band"]) == 2
+
+    assert 'mean' in ds.data_vars
+    assert ds["mean"].dims == ("feature", "var", "band")
 
 
 ###########
@@ -348,13 +357,12 @@ def test_xarray_writer_from_da(point_features):
     square = make_rect(0.5, 0.5, 2.5, 2.5)
 
     from exactextract import exact_extract
-    da = exact_extract(rast, square, ["count", "sum"], output=XArrayWriter())
+    ds = exact_extract(rast, square, ["count", "sum"], output=XArrayWriter())
 
-    assert isinstance(da, xr.DataArray)
-    assert len(da.coords["feature"]) == 1
-    assert da.dims == ('feature', 'stat')
-    assert 'count' in da.coords["stat"]
-    assert 'sum' in da.coords["stat"]
+    assert isinstance(ds, xr.Dataset)
+    assert len(ds.coords["feature"]) == 1
+    assert ds['count'].dims == ('feature',)
+    assert ds['sum'].dims == ('feature',)
 
 def test_xarray_writer_from_da_with_time(point_features):
     xr = pytest.importorskip("xarray")
@@ -365,14 +373,13 @@ def test_xarray_writer_from_da_with_time(point_features):
     square = make_rect(0.5, 0.5, 2.5, 2.5)
 
     from exactextract import exact_extract
-    da = exact_extract(rast, square, ["count", "sum"], output=XArrayWriter())
+    ds = exact_extract(rast, square, ["count", "sum"], output=XArrayWriter())
 
-    assert isinstance(da, xr.DataArray)
-    assert len(da.coords["feature"]) == 1
-    assert len(da.coords["band"]) == 3
-    assert da.dims == ('feature', 'band', 'stat')
-    assert 'count' in da.coords["stat"]
-    assert 'sum' in da.coords["stat"]
+    assert isinstance(ds, xr.Dataset)
+    assert len(ds.coords["feature"]) == 1
+    assert len(ds.coords["band"]) == 3
+    assert ds['count'].dims == ('feature', 'band')
+    assert ds['sum'].dims == ('feature', 'band')
 
 def test_xarray_writer_from_ds(point_features):
     xr = pytest.importorskip("xarray")
@@ -388,10 +395,9 @@ def test_xarray_writer_from_ds(point_features):
 
     assert isinstance(ds, xr.Dataset)
     assert len(ds.coords["feature"]) == 1
-    assert ds['var1'].dims == ('feature', 'stat')
-    assert ds['var2'].dims == ('feature', 'stat')
-    assert 'count' in ds.coords["stat"]
-    assert 'sum' in ds.coords["stat"]
+    assert len(ds.coords["var"]) == 2
+    assert ds['count'].dims == ('feature', 'var')
+    assert ds['sum'].dims == ('feature', 'var')
 
 def test_xarray_writer_from_ds_with_time(point_features):
     xr = pytest.importorskip("xarray")
@@ -407,8 +413,7 @@ def test_xarray_writer_from_ds_with_time(point_features):
 
     assert isinstance(ds, xr.Dataset)
     assert len(ds.coords["feature"]) == 1
+    assert len(ds.coords["var"]) == 2
     assert len(ds.coords["band"]) == 3
-    assert ds['var1'].dims == ('feature', 'band', 'stat')
-    assert ds['var2'].dims == ('feature', 'band', 'stat')
-    assert 'count' in ds.coords["stat"]
-    assert 'sum' in ds.coords["stat"]
+    assert ds['count'].dims == ('feature', 'var', 'band')
+    assert ds['sum'].dims == ('feature', 'var', 'band')

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -1,10 +1,11 @@
 import json
 
 import pytest
+import numpy as np
 
 from exactextract import Operation
 from exactextract.feature import JSONFeature
-from exactextract.writer import GDALWriter, JSONWriter, PandasWriter, QGISWriter
+from exactextract.writer import GDALWriter, JSONWriter, PandasWriter, QGISWriter, XArrayWriter
 
 
 @pytest.fixture()
@@ -179,3 +180,27 @@ def test_qgis_writer(np_raster_source, point_features):
     assert qgs_features[0].geometry().asWkt() == "Point (3 8)"
     assert qgs_features[1].hasGeometry()
     assert qgs_features[1].geometry().asWkt() == "Point (2 2)"
+
+
+def test_xarray_writer(np_raster_source, point_features):
+    xr = pytest.importorskip("xarray")
+
+    times = np.array([np.datetime64("2020-01-01"), np.datetime64("2020-02-01")])
+
+    w = XArrayWriter(dim_name="time", dim_coords=times)
+
+    w.add_column("id")
+    w.add_operation(Operation("mean", "band_1_mean", np_raster_source))
+    w.add_operation(Operation("mean", "band_2_mean", np_raster_source))
+
+    for f in point_features:
+        f.feature["properties"]["band_1_mean"] = float(f.feature["id"])
+        f.feature["properties"]["band_2_mean"] = float(f.feature["id"]) * 2
+        w.write(f)
+
+    ds = w.features()
+
+    assert isinstance(ds, xr.Dataset)
+    assert ds.dims["feature"] == 2
+    assert ds.dims["time"] == 2
+    np.testing.assert_array_equal(ds.coords["time"], times)

--- a/python/tests/test_writer.py
+++ b/python/tests/test_writer.py
@@ -181,26 +181,234 @@ def test_qgis_writer(np_raster_source, point_features):
     assert qgs_features[1].hasGeometry()
     assert qgs_features[1].geometry().asWkt() == "Point (2 2)"
 
-
-def test_xarray_writer(np_raster_source, point_features):
+def test_xarray_writer_stat(np_raster_source, point_features):
     xr = pytest.importorskip("xarray")
 
-    times = np.array([np.datetime64("2020-01-01"), np.datetime64("2020-02-01")])
+    w = XArrayWriter()
 
-    w = XArrayWriter(dim_name="time", dim_coords=times)
+    w.add_column("id")
+    w.add_operation(Operation("mean", "mean", np_raster_source))
+    w.add_operation(Operation("sum", "sum", np_raster_source))
+
+    for f in point_features:
+        f.feature["properties"]["mean"] = float(f.feature["id"])
+        f.feature["properties"]["sum"] = float(f.feature["id"]) * 2
+        w.write(f)
+
+    da = w.features()
+
+    assert isinstance(da, xr.DataArray)
+    assert len(da.coords["feature"]) == 2
+    assert len(da.coords["id"]) == 2
+    assert 'mean' in da.coords["stat"]
+    assert 'sum' in da.coords["stat"]
+    assert "band" not in da.coords
+
+def test_xarray_writer_band_stat(np_raster_source, point_features):
+    xr = pytest.importorskip("xarray")
+
+    w = XArrayWriter()
 
     w.add_column("id")
     w.add_operation(Operation("mean", "band_1_mean", np_raster_source))
     w.add_operation(Operation("mean", "band_2_mean", np_raster_source))
+    w.add_operation(Operation("mean", "band_1_sum", np_raster_source))
+    w.add_operation(Operation("mean", "band_2_sum", np_raster_source))
 
     for f in point_features:
         f.feature["properties"]["band_1_mean"] = float(f.feature["id"])
         f.feature["properties"]["band_2_mean"] = float(f.feature["id"]) * 2
+        f.feature["properties"]["band_1_sum"] = float(f.feature["id"])
+        f.feature["properties"]["band_2_sum"] = float(f.feature["id"]) * 2
+        w.write(f)
+
+    da = w.features()
+
+    assert isinstance(da, xr.DataArray)
+    assert len(da.coords["feature"]) == 2
+    assert len(da.coords["id"]) == 2
+    assert len(da.coords["band"]) == 2
+    assert 'mean' in da.coords["stat"]
+    assert 'sum' in da.coords["stat"]
+
+def test_xarray_writer_var_stat(np_raster_source, point_features):
+    xr = pytest.importorskip("xarray")
+
+    w = XArrayWriter()
+
+    w.add_column("id")
+    w.add_operation(Operation("mean", "t2m_mean", np_raster_source))
+    w.add_operation(Operation("mean", "tp_mean", np_raster_source))
+    w.add_operation(Operation("sum", "t2m_sum", np_raster_source))
+    w.add_operation(Operation("sum", "tp_sum", np_raster_source))
+
+    for f in point_features:
+        f.feature["properties"]["t2m_mean"] = float(f.feature["id"])
+        f.feature["properties"]["tp_mean"] = float(f.feature["id"]) * 2
+        f.feature["properties"]["t2m_sum"] = float(f.feature["id"])
+        f.feature["properties"]["tp_sum"] = float(f.feature["id"]) * 2
         w.write(f)
 
     ds = w.features()
 
     assert isinstance(ds, xr.Dataset)
-    assert ds.dims["feature"] == 2
-    assert ds.dims["time"] == 2
-    np.testing.assert_array_equal(ds.coords["time"], times)
+    assert len(ds.coords["feature"]) == 2
+    assert len(ds.coords["id"]) == 2
+    assert "band" not in ds.coords
+    assert 'mean' in ds.coords["stat"]
+    assert 'sum' in ds.coords["stat"]
+    assert ds["t2m"].dims == ("feature", "stat")
+    assert ds["tp"].dims == ("feature", "stat")
+
+
+def test_xarray_writer_var_band_stat(np_raster_source, point_features):
+    xr = pytest.importorskip("xarray")
+
+    w = XArrayWriter()
+
+    w.add_column("id")
+    w.add_operation(Operation("mean", "t2m_band_1_mean", np_raster_source))
+    w.add_operation(Operation("mean", "tp_band_1_mean", np_raster_source))
+    w.add_operation(Operation("mean", "t2m_band_2_mean", np_raster_source))
+    w.add_operation(Operation("mean", "tp_band_2_mean", np_raster_source))
+
+    for f in point_features:
+        f.feature["properties"]["t2m_band_1_mean"] = float(f.feature["id"])
+        f.feature["properties"]["tp_band_1_mean"] = float(f.feature["id"]) * 2
+        f.feature["properties"]["t2m_band_2_mean"] = float(f.feature["id"])
+        f.feature["properties"]["tp_band_2_mean"] = float(f.feature["id"]) * 2
+        w.write(f)
+
+    ds = w.features()
+
+    assert isinstance(ds, xr.Dataset)
+    assert len(ds.coords["feature"]) == 2
+    assert len(ds.coords["id"]) == 2
+    assert 'mean' in ds.coords["stat"]
+    assert ds["t2m"].dims == ("feature", "band", "stat")
+    assert ds["tp"].dims == ("feature", "band", "stat")
+
+
+###########
+# BELOW TESTS FOR ACTUAL XARRAY INPUT SO SHOULD MAYBE BE ELSEWHERE
+
+def make_rect(xmin, ymin, xmax, ymax, id=None, properties=None):
+    f = {
+        "type": "Feature",
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [[xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax], [xmin, ymin]]
+            ],
+        },
+    }
+
+    if id is not None:
+        f["id"] = id
+    if properties is not None:
+        f["properties"] = properties
+
+    return f
+
+def make_xarray(xmin, ymin, xmax, ymax, n):
+    import xarray as xr
+    da = xr.DataArray(
+        data=np.ones((n, n)),
+        dims=["y", "x"],
+        coords={
+            "x": np.linspace(xmin, xmax, n),
+            "y": np.linspace(ymin, ymax, n),
+        },
+    )
+    return da
+
+def make_xarray_with_time(xmin, ymin, xmax, ymax, n):
+    import xarray as xr
+    da = xr.DataArray(
+        data=np.stack([
+            np.ones((n, n)) * 1, # time 1
+            np.ones((n, n)) * 2, # time 2
+            np.ones((n, n)) * 3, # time 3
+        ]),
+        dims=["time", "y", "x"],
+        coords={
+            "time": ["2021-01-01", "2021-02-01", "2021-03-01"],
+            "x": np.linspace(xmin, xmax, n),
+            "y": np.linspace(ymin, ymax, n),
+        },
+    )
+    return da
+
+def test_xarray_writer_from_da(point_features):
+    xr = pytest.importorskip("xarray")
+    rxr = pytest.importorskip("rioxarray")
+
+    rast = make_xarray(0, 0, 3, 3, n=10)
+
+    square = make_rect(0.5, 0.5, 2.5, 2.5)
+
+    from exactextract import exact_extract
+    da = exact_extract(rast, square, ["count", "sum"], output=XArrayWriter())
+
+    assert isinstance(da, xr.DataArray)
+    assert len(da.coords["feature"]) == 1
+    assert da.dims == ('feature', 'stat')
+    assert 'count' in da.coords["stat"]
+    assert 'sum' in da.coords["stat"]
+
+def test_xarray_writer_from_da_with_time(point_features):
+    xr = pytest.importorskip("xarray")
+    rxr = pytest.importorskip("rioxarray")
+
+    rast = make_xarray_with_time(0, 0, 3, 3, n=10)
+
+    square = make_rect(0.5, 0.5, 2.5, 2.5)
+
+    from exactextract import exact_extract
+    da = exact_extract(rast, square, ["count", "sum"], output=XArrayWriter())
+
+    assert isinstance(da, xr.DataArray)
+    assert len(da.coords["feature"]) == 1
+    assert len(da.coords["band"]) == 3
+    assert da.dims == ('feature', 'band', 'stat')
+    assert 'count' in da.coords["stat"]
+    assert 'sum' in da.coords["stat"]
+
+def test_xarray_writer_from_ds(point_features):
+    xr = pytest.importorskip("xarray")
+    rxr = pytest.importorskip("rioxarray")
+
+    arr = make_xarray(0, 0, 3, 3, n=10)
+    rast = xr.Dataset({'var1': arr, 'var2': arr * 2})
+
+    square = make_rect(0.5, 0.5, 2.5, 2.5)
+
+    from exactextract import exact_extract
+    ds = exact_extract(rast, square, ["count", "sum"], output=XArrayWriter())
+
+    assert isinstance(ds, xr.Dataset)
+    assert len(ds.coords["feature"]) == 1
+    assert ds['var1'].dims == ('feature', 'stat')
+    assert ds['var2'].dims == ('feature', 'stat')
+    assert 'count' in ds.coords["stat"]
+    assert 'sum' in ds.coords["stat"]
+
+def test_xarray_writer_from_ds_with_time(point_features):
+    xr = pytest.importorskip("xarray")
+    rxr = pytest.importorskip("rioxarray")
+
+    arr = make_xarray_with_time(0, 0, 3, 3, n=10)
+    rast = xr.Dataset({'var1': arr, 'var2': arr * 2})
+
+    square = make_rect(0.5, 0.5, 2.5, 2.5)
+
+    from exactextract import exact_extract
+    ds = exact_extract(rast, square, ["count", "sum"], output=XArrayWriter())
+
+    assert isinstance(ds, xr.Dataset)
+    assert len(ds.coords["feature"]) == 1
+    assert len(ds.coords["band"]) == 3
+    assert ds['var1'].dims == ('feature', 'band', 'stat')
+    assert ds['var2'].dims == ('feature', 'band', 'stat')
+    assert 'count' in ds.coords["stat"]
+    assert 'sum' in ds.coords["stat"]


### PR DESCRIPTION
## Description

This PR adds support for returning results of exact_extract() as multidimensional xarray. Addresses the issues raised in #191 , where current output formats adds results as one or more columns whose names have to be parsed by enduser, which adds a bit of overhead and error especially when working with multiple variables or timeseries bands. By returning as multidimensional xarray, we instead can select and manipulate each dimension directly. 

## Specific changes

- Added XArrayWriter class which processes the output from the C++ results. 
- The dimensions are constructed by parsing the column names returned by the C++ engine, and have tried to make this as robust as possible. 
- The `output` arg of the `exact_extract()` function can now be set to `xarray` to use the new XArrayWriter and return the results as xarray.Dataset. Updated the function docstring accordingly. 
- Added writer-specific tests that mimics the other writer tests, and various permutations of input-output dimensions. 
- Added 'xarray' to the output parameterizations of existing `exact_extract()` tests, and other tests mimicing tests for the existing output formats. 

## Behavior

When setting `output='xarray'`, the `exact_extract()` function always returns an xarray.Dataset, with one or more data variables, one for each of the requested statistics. So to access the results for a particular statistic:

    result_ds = exact_extract(raster, features, ['mean'], output='xarray)
    mean_da = result_ds['mean']

This provides a consistent return format, and is similar to how the pandas output format also accesses each statistic by indexing on a statistics column, e.g. `df['mean']`. 

The resulting xarray.DataArray will always have dimension `feature` which contains the positional index of each input feature. By adding other variables in `include_cols`, these will be added as coordinate labels belong to the `feature` dimension, which means we can add extra feature columns and later select a feature based on it, eg:

    result_ds = exact_extract(raster, features, ['mean'], include_cols=['feature_name'], output='xarray')
    mean_feat_A = result_ds['mean'].sel(feature_name='A').values

### Multiple variables

If the input raster has multiple variables, e.g. t2m and tp representing 30-year climate averages, the output will also have a `var` dimension which can be queried:

    mean_precip = result_ds.sel(var='tp')

If there is only one variable then the `var` dimension will be absent from the output. 

### Multiple bands

If the input raster has multiple bands, e.g. is a timeseries data with one band per day between 2025-01-01 and 2025-01-31, the output will also have a `band` dimension containing the band index number (starting at 1) which can be queried. So to get the 3rd day: 

    mean_day_3 = result_ds.sel(band=3)

If there is only one band then there will be no `band` dimension in the output. 

## Timeseries use-case

Addressing the issues raised in #191 specifically, consider that we have a NetCDF file of precipitation and temperature for a country with monthly values for a given year. And i want to summarize the spatial average of temperature and precipitation for country districts and present this as a long-format monthly timeseries CSV file. 

    result_ds = exact_extract(monthly_climate_raster, admin_units, ['mean'], include_cols=['name'], output='xarray')

To assign meaning to each band number, we manually add new 'time` coordinates tied to the band dim: 

    month_timestamps = monthly_climate_raster['time'].values
    result_ds = result_ds.assign_coords(time=('band', month_timestamps))

Finally, we just convert to Pandas dataframe and output to CSV. 

    result_ds.to_dataframe().to_csv('district_climate_means.csv')

The CSV file should now have feature index (along with district name from include_cols), variable name, band number (along with time which we added) going down as rows, and separate columns for each of the statistics, looking something like this:

feature | name | var | band | time | mean | std | p90
-- | -- | -- | -- | -- | -- | -- | --
0 | Oslo | ndvi | 1 | 2025-01 | 0.4 | 0.1 | 0.6
| | | ndvi | 2 | 2025-02 | 0.5 | 0.12 | 0.7
| | | evi | 1 | 2025-01 | 0.3 | 0.05 | 0.5
| | | evi | 2 | 2025-02 | 0.35 | 0.06 | 0.55
1 | New York | ndvi | 1 | 2025-01 | ... | ... | ...

## Questions

1. Are the suggested dimension names and ordering reasonable, or any other suggestions? I.e. feature, var, band. 
2. The current PR only adds a single band dim with flat numbers which have to be assigned meaning. I would also like to add an additional convenience of automatically detecting the dimension coordinates from the input data, so that the resulting xarray has the same dimensions as the input data. The simplest case is where the input bands are equivalent to a time coordinates, so the resulting xarray has a `time` dimension with date values rather than the current `band` dimension with flat numbers. However, this could get complicated, especially if there are multiple dimensions involved, so wondering if this should come as a separate PR? For now one can do the quick solution shown in the Timeseries Use Case above. 
3. See also questions added as inline code comments. 
4. I was able to setup a local dev version of exactextract and run the full test suite, although it's probably good you do a separate run. The only ones that fail are two having to do with int/float equality, but not sure how to get fix it: 

    FAILED python/tests/test_exact_extract.py::test_basic_stats[values-expected14-xarray] - AssertionError: assert dtype('int32') == dtype('float64')
    FAILED python/tests/test_exact_extract.py::test_basic_stats[cell_id-expected18-xarray] - AssertionError: assert dtype('int64') == dtype('float64')

5. There may be some inconsistencies with code formatting, quotation marks, etc, I did not run it through any linter. I wanted to focus on the content first, and wait to polish up the code to match preferences and linting towards the end. 